### PR TITLE
feat: Implement DynamoDBConfigStore with AWS SDK

### DIFF
--- a/libs/config/package.json
+++ b/libs/config/package.json
@@ -14,7 +14,9 @@
   },
   "dependencies": {
     "@agent-desktop/types": "workspace:*",
-    "@agent-desktop/logging": "workspace:*"
+    "@agent-desktop/logging": "workspace:*",
+    "@aws-sdk/client-dynamodb": "^3.500.0",
+    "@aws-sdk/lib-dynamodb": "^3.500.0"
   },
   "devDependencies": {
     "typescript": "^5.0.2",

--- a/libs/config/src/config.store.ts
+++ b/libs/config/src/config.store.ts
@@ -10,6 +10,14 @@ import type {
 } from '@agent-desktop/types';
 import { success, failure } from '@agent-desktop/types';
 import type { Logger } from '@agent-desktop/logging';
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  DeleteCommand,
+  ScanCommand
+} from "@aws-sdk/lib-dynamodb";
 
 /**
  * Configuration storage interface
@@ -35,13 +43,15 @@ export interface IConfigStore {
 export class DynamoDBConfigStore implements IConfigStore {
   private readonly tableName: string;
   private readonly logger: Logger;
+  private readonly ddbDocClient: DynamoDBDocumentClient;
   
   constructor(tableName: string, logger?: Logger) {
     this.tableName = tableName;
+    // Initialize logger (existing code)
     if (logger) {
       this.logger = logger.createChild('DynamoDBConfigStore');
     } else {
-      // Fallback logger
+      // Fallback logger (existing code)
       this.logger = {
         debug: (message, context) => console.debug(`[DynamoDBConfigStore] ${message}`, context || ''),
         info: (message, context) => console.info(`[DynamoDBConfigStore] ${message}`, context || ''),
@@ -50,6 +60,9 @@ export class DynamoDBConfigStore implements IConfigStore {
         createChild: () => this.logger, // Simplistic child creation
       } as Logger;
     }
+
+    const client = new DynamoDBClient({}); // Basic client configuration, region can be configured via ENV variables or shared config
+    this.ddbDocClient = DynamoDBDocumentClient.from(client);
   }
 
   /**
@@ -58,37 +71,35 @@ export class DynamoDBConfigStore implements IConfigStore {
   async getCustomerConfig(customerId: string): Promise<Result<CustomerConfig, Error>> {
     this.logger.info('Getting customer configuration', { customerId });
 
-    // TODO: AWS SDK - Replace with actual DynamoDB getItem call
-    // Example:
-    // const dynamodb = new AWS.DynamoDB.DocumentClient();
-    // const params = {
-    //   TableName: this.tableName,
-    //   Key: { PK: `CUSTOMER#\${customerId}`, SK: 'CONFIG' },
-    // };
-    // const result = await dynamodb.get(params).promise();
-    // if (!result.Item) return failure(new Error('Customer configuration not found'));
-    // return success(result.Item as CustomerConfig);
+    const params = {
+      TableName: this.tableName,
+      Key: { PK: `CUSTOMER#${customerId}`, SK: 'CONFIG' },
+    };
 
     try {
-      // Mock implementation - Placeholder for actual AWS SDK call
-      this.logger.warn('Mock implementation: Returning dummy data for getCustomerConfig', { customerId });
-      // const mockConfig = this.createMockCustomerConfig(customerId); // createMockCustomerConfig will be removed
-      // For now, to keep it compiling without the method, let's return a very basic mock or error
-      return failure(new Error(`Mock for getCustomerConfig for ${customerId} - needs AWS SDK implementation.`));
-      
-      // this.logger.info('Customer configuration retrieved successfully', {
-      //   customerId,
-      //   moduleCount: mockConfig.modules.length,
-      // });
+      this.logger.debug('Attempting to get item from DynamoDB', params);
+      const { Item } = await this.ddbDocClient.send(new GetCommand(params));
 
-      // return success(mockConfig);
-    } catch (error) {
-      this.logger.error('Failed to get customer configuration', {
+      if (!Item) {
+        this.logger.warn('Customer configuration not found', { customerId });
+        return failure(new Error('Customer configuration not found'));
+      }
+
+      this.logger.info('Customer configuration retrieved successfully', {
         customerId,
-        error: error instanceof Error ? error.message : String(error),
+        // It's good practice to not log the entire config item if it contains sensitive data.
+        // Consider logging specific, non-sensitive fields if needed for debugging.
+        // For example: version: Item.version
       });
-
-      return failure(error instanceof Error ? error : new Error(String(error)));
+      return success(Item as CustomerConfig);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error('Failed to get customer configuration from DynamoDB', {
+        customerId,
+        error: errorMessage,
+        stack: error instanceof Error ? error.stack : undefined
+      });
+      return failure(error instanceof Error ? error : new Error(errorMessage));
     }
   }
 
@@ -101,35 +112,34 @@ export class DynamoDBConfigStore implements IConfigStore {
       version: config.version,
     });
 
-    // TODO: AWS SDK - Replace with actual DynamoDB putItem call
-    // Example:
-    // const dynamodb = new AWS.DynamoDB.DocumentClient();
-    // const item = {
-    //   PK: `CUSTOMER#\${config.customer_id}`,
-    //   SK: 'CONFIG',
-    //   ...config,
-    //   updatedAt: new Date().toISOString(),
-    // };
-    // const params = { TableName: this.tableName, Item: item };
-    // await dynamodb.put(params).promise();
-    // return success(undefined);
+    const item = {
+      PK: `CUSTOMER#${config.customer_id}`,
+      SK: 'CONFIG',
+      ...config,
+      updatedAt: new Date().toISOString(),
+    };
+
+    const params = {
+      TableName: this.tableName,
+      Item: item,
+    };
 
     try {
-      // Mock implementation - Placeholder for actual AWS SDK call
-      this.logger.warn('Mock implementation: saveCustomerConfig called', { customerId: config.customer_id });
-      this.logger.info('Customer configuration saved successfully (mock)', {
+      this.logger.debug('Attempting to put item into DynamoDB', params);
+      await this.ddbDocClient.send(new PutCommand(params));
+      this.logger.info('Customer configuration saved successfully', {
         customerId: config.customer_id,
         version: config.version,
       });
-
       return success(undefined);
     } catch (error) {
-      this.logger.error('Failed to save customer configuration', {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error('Failed to save customer configuration to DynamoDB', {
         customerId: config.customer_id,
-        error: error instanceof Error ? error.message : String(error),
+        error: errorMessage,
+        stack: error instanceof Error ? error.stack : undefined
       });
-
-      return failure(error instanceof Error ? error : new Error(String(error)));
+      return failure(error instanceof Error ? error : new Error(errorMessage));
     }
   }
 
@@ -139,28 +149,24 @@ export class DynamoDBConfigStore implements IConfigStore {
   async deleteCustomerConfig(customerId: string): Promise<Result<void, Error>> {
     this.logger.info('Deleting customer configuration', { customerId });
 
-    // TODO: AWS SDK - Replace with actual DynamoDB deleteItem call
-    // Example:
-    // const dynamodb = new AWS.DynamoDB.DocumentClient();
-    // const params = {
-    //   TableName: this.tableName,
-    //   Key: { PK: `CUSTOMER#\${customerId}`, SK: 'CONFIG' },
-    // };
-    // await dynamodb.delete(params).promise();
-    // return success(undefined);
+    const params = {
+      TableName: this.tableName,
+      Key: { PK: `CUSTOMER#${customerId}`, SK: 'CONFIG' },
+    };
 
     try {
-      // Mock implementation - Placeholder for actual AWS SDK call
-      this.logger.warn('Mock implementation: deleteCustomerConfig called', { customerId });
-      this.logger.info('Customer configuration deleted successfully (mock)', { customerId });
+      this.logger.debug('Attempting to delete item from DynamoDB', params);
+      await this.ddbDocClient.send(new DeleteCommand(params));
+      this.logger.info('Customer configuration deleted successfully', { customerId });
       return success(undefined);
     } catch (error) {
-      this.logger.error('Failed to delete customer configuration', {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error('Failed to delete customer configuration from DynamoDB', {
         customerId,
-        error: error instanceof Error ? error.message : String(error),
+        error: errorMessage,
+        stack: error instanceof Error ? error.stack : undefined
       });
-
-      return failure(error instanceof Error ? error : new Error(String(error)));
+      return failure(error instanceof Error ? error : new Error(errorMessage));
     }
   }
 
@@ -168,37 +174,44 @@ export class DynamoDBConfigStore implements IConfigStore {
    * List all customer configurations
    */
   async listCustomerConfigs(): Promise<Result<CustomerConfig[], Error>> {
-    this.logger.info('Listing customer configurations');
+    this.logger.info('Listing all customer configurations');
 
-    // TODO: AWS SDK - Replace with actual DynamoDB scan or query call
-    // Example (Scan - potentially inefficient for large tables):
-    // const dynamodb = new AWS.DynamoDB.DocumentClient();
-    // const params = {
-    //   TableName: this.tableName,
-    //   FilterExpression: "begins_with(PK, :pk_prefix) AND SK = :sk_value",
-    //   ExpressionAttributeValues: { ":pk_prefix": "CUSTOMER#", ":sk_value": "CONFIG" }
-    // };
-    // const result = await dynamodb.scan(params).promise();
-    // return success(result.Items as CustomerConfig[]);
-    // Consider pagination for large datasets (LastEvaluatedKey).
-    // A GSI might be more appropriate for querying all customer configs.
+    // TODO: Consider GSI for performance on large tables instead of Scan.
+    // A GSI on a common attribute or on the SK (if SK='CONFIG' is sparse for other items)
+    // could be more efficient. For now, using Scan with a filter.
+    const params = {
+      TableName: this.tableName,
+      FilterExpression: "begins_with(PK, :pk_prefix) AND SK = :sk_value",
+      ExpressionAttributeValues: {
+        ":pk_prefix": "CUSTOMER#",
+        ":sk_value": "CONFIG",
+      },
+    };
 
     try {
-      // Mock implementation - Placeholder for actual AWS SDK call
-      this.logger.warn('Mock implementation: Returning empty array for listCustomerConfigs');
-      const mockConfigs: CustomerConfig[] = [];
+      this.logger.debug('Attempting to scan items from DynamoDB', params);
+      // Note: Scan operations can be slow and costly on large tables.
+      // Consider pagination if many config items are expected.
+      const { Items } = await this.ddbDocClient.send(new ScanCommand(params));
 
-      this.logger.info('Customer configurations listed successfully (mock)', {
-        count: mockConfigs.length,
+      if (!Items) {
+        // This case might not be typical for Scan if the table exists,
+        // an empty array would be more common.
+        this.logger.warn('No customer configurations found or error in scan operation that resulted in no Items array.');
+        return success([]);
+      }
+
+      this.logger.info('Customer configurations listed successfully', {
+        count: Items.length,
       });
-
-      return success(mockConfigs);
+      return success(Items as CustomerConfig[]);
     } catch (error) {
-      this.logger.error('Failed to list customer configurations', {
-        error: error instanceof Error ? error.message : String(error),
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error('Failed to list customer configurations from DynamoDB', {
+        error: errorMessage,
+        stack: error instanceof Error ? error.stack : undefined
       });
-
-      return failure(error instanceof Error ? error : new Error(String(error)));
+      return failure(error instanceof Error ? error : new Error(errorMessage));
     }
   }
 
@@ -209,38 +222,46 @@ export class DynamoDBConfigStore implements IConfigStore {
     this.logger.info('Getting module configuration', { customerId, moduleId });
 
     // TODO: AWS SDK - Current mock relies on getCustomerConfig.
-    // If modules were separate items, this would be a direct getItem:
-    // Key: { PK: `CUSTOMER#\${customerId}`, SK: `MODULE#\${moduleId}` }
+    // If modules were separate items, this would be a direct GetCommand similar to getCustomerConfig.
+
     try {
       const customerConfigResult = await this.getCustomerConfig(customerId);
+
       if (!customerConfigResult.success) {
-        // If getCustomerConfig is a mock returning failure, this path will be taken.
-        this.logger.warn('getModuleConfig: getCustomerConfig failed (mock behavior)', { customerId });
-        return failure(new Error(`Cannot get module, as getCustomerConfig failed for ${customerId} (mock).`));
+        this.logger.warn('Failed to get customer configuration while trying to get module config', {
+          customerId,
+          moduleId,
+          error: customerConfigResult.error.message,
+        });
+        // Propagate the error from getCustomerConfig
+        return failure(new Error(`Failed to retrieve customer config for module fetching: ${customerConfigResult.error.message}`));
       }
 
-      // This part assumes getCustomerConfig returned a valid (though potentially mock) CustomerConfig
-      // As getCustomerConfig mock now returns failure, this part is less likely to be hit
-      // unless the mock for getCustomerConfig is changed to return success with some data.
-      const moduleConfig = customerConfigResult.data.modules.find(m => m.module_id === moduleId);
+      const customerConfig = customerConfigResult.data;
+      const moduleConfig = customerConfig.modules?.find(m => m.module_id === moduleId);
+
       if (!moduleConfig) {
-        return failure(new Error(`Module configuration not found: ${moduleId} in mock customer config for ${customerId}`));
+        this.logger.warn('Module configuration not found for customer', { customerId, moduleId });
+        return failure(new Error(`Module configuration not found: ${moduleId}`));
       }
 
-      this.logger.info('Module configuration retrieved successfully (from mock customer config)', {
+      this.logger.info('Module configuration retrieved successfully', {
         customerId,
         moduleId,
+        // moduleVersion: moduleConfig.version // Example if module has a version
       });
-
       return success(moduleConfig);
     } catch (error) {
+      // This catch block might be redundant if getCustomerConfig handles its errors thoroughly
+      // and converts them to `Result` objects. However, it's a safeguard.
+      const errorMessage = error instanceof Error ? error.message : String(error);
       this.logger.error('Failed to get module configuration', {
         customerId,
         moduleId,
-        error: error instanceof Error ? error.message : String(error),
+        error: errorMessage,
+        stack: error instanceof Error ? error.stack : undefined
       });
-
-      return failure(error instanceof Error ? error : new Error(String(error)));
+      return failure(error instanceof Error ? error : new Error(errorMessage));
     }
   }
 
@@ -251,38 +272,73 @@ export class DynamoDBConfigStore implements IConfigStore {
     this.logger.info('Saving module configuration', {
       customerId,
       moduleId: config.module_id,
+      // moduleVersion: config.version // If applicable
     });
 
-    // TODO: AWS SDK - Current mock relies on getCustomerConfig and saveCustomerConfig.
-    // If modules were separate items, this could be a direct putItem for the module:
-    // Item: { PK: `CUSTOMER#\${customerId}`, SK: `MODULE#\${config.module_id}`, ...module_specific_data }
-    // Or it might involve updating a list of modules in the main customer config item if modules are not too large.
+    // This method relies on a get-modify-put pattern for the entire customer configuration.
+    // For high-concurrency environments or large config objects,
+    // consider updating only the specific module using conditional updates if possible,
+    // or storing modules as separate DynamoDB items.
+
     try {
       const customerConfigResult = await this.getCustomerConfig(customerId);
+
       if (!customerConfigResult.success) {
-        this.logger.warn('saveModuleConfig: getCustomerConfig failed (mock behavior)', { customerId });
-        return failure(new Error(`Cannot save module, as getCustomerConfig failed for ${customerId} (mock).`));
+        this.logger.warn('Failed to get customer configuration while trying to save module config', {
+          customerId,
+          moduleId: config.module_id,
+          error: customerConfigResult.error.message,
+        });
+        return failure(new Error(`Failed to retrieve customer config for module saving: ${customerConfigResult.error.message}`));
       }
 
       const customerConfig = customerConfigResult.data;
-      const moduleIndex = customerConfig.modules.findIndex(m => m.module_id === config.module_id);
       
+      // Ensure modules array exists
+      if (!customerConfig.modules) {
+          customerConfig.modules = [];
+      }
+
+      const moduleIndex = customerConfig.modules.findIndex(m => m.module_id === config.module_id);
+
       if (moduleIndex >= 0) {
         customerConfig.modules[moduleIndex] = config;
       } else {
         customerConfig.modules.push(config);
       }
 
-      customerConfig.updatedAt = new Date(); // This assumes CustomerConfig has an updatedAt field
-      return this.saveCustomerConfig(customerConfig); // This will call the mocked saveCustomerConfig
+      // Assuming CustomerConfig has an 'updatedAt' field that should be set by saveCustomerConfig.
+      // If CustomerConfig type definition doesn't have 'updatedAt', this might be an issue,
+      // but saveCustomerConfig itself adds 'updatedAt' before sending to DynamoDB.
+      // No need to set customerConfig.updatedAt = new Date(); here as saveCustomerConfig handles it.
+
+      this.logger.debug('Attempting to save updated customer configuration for module change', { customerId, moduleId: config.module_id });
+      const saveResult = await this.saveCustomerConfig(customerConfig);
+
+      if (!saveResult.success) {
+        this.logger.error('Failed to save customer configuration after updating module', {
+          customerId,
+          moduleId: config.module_id,
+          error: saveResult.error.message,
+        });
+        return failure(new Error(`Failed to save customer config after module update: ${saveResult.error.message}`));
+      }
+
+      this.logger.info('Module configuration saved successfully by updating customer config', {
+        customerId,
+        moduleId: config.module_id,
+      });
+      return success(undefined);
     } catch (error) {
+      // This catch block is a general safeguard.
+      const errorMessage = error instanceof Error ? error.message : String(error);
       this.logger.error('Failed to save module configuration', {
         customerId,
         moduleId: config.module_id,
-        error: error instanceof Error ? error.message : String(error),
+        error: errorMessage,
+        stack: error instanceof Error ? error.stack : undefined
       });
-
-      return failure(error instanceof Error ? error : new Error(String(error)));
+      return failure(error instanceof Error ? error : new Error(errorMessage));
     }
   }
 
@@ -292,30 +348,70 @@ export class DynamoDBConfigStore implements IConfigStore {
   async deleteModuleConfig(customerId: string, moduleId: string): Promise<Result<void, Error>> {
     this.logger.info('Deleting module configuration', { customerId, moduleId });
 
-    // TODO: AWS SDK - Current mock relies on getCustomerConfig and saveCustomerConfig.
-    // If modules were separate items, this could be a direct deleteItem for the module:
-    // Key: { PK: `CUSTOMER#\${customerId}`, SK: `MODULE#\${moduleId}` }
-    // Or it might involve updating the list of modules in the main customer config item.
+    // This method also relies on a get-modify-put pattern for the entire customer configuration.
+    // Similar considerations as saveModuleConfig apply here regarding concurrency and large objects.
+
     try {
       const customerConfigResult = await this.getCustomerConfig(customerId);
+
       if (!customerConfigResult.success) {
-        this.logger.warn('deleteModuleConfig: getCustomerConfig failed (mock behavior)', { customerId });
-        return failure(new Error(`Cannot delete module, as getCustomerConfig failed for ${customerId} (mock).`));
+        this.logger.warn('Failed to get customer configuration while trying to delete module config', {
+          customerId,
+          moduleId,
+          error: customerConfigResult.error.message,
+        });
+        return failure(new Error(`Failed to retrieve customer config for module deletion: ${customerConfigResult.error.message}`));
       }
 
       const customerConfig = customerConfigResult.data;
-      customerConfig.modules = customerConfig.modules.filter(m => m.module_id !== moduleId);
-      // customerConfig.updatedAt = new Date(); // This assumes CustomerConfig has an updatedAt field
 
-      return this.saveCustomerConfig(customerConfig); // This will call the mocked saveCustomerConfig
-    } catch (error) {
-      this.logger.error('Failed to delete module configuration (mock)', {
+      if (!customerConfig.modules) {
+        // If modules array doesn't exist, the module to delete also doesn't exist.
+        this.logger.warn('Modules array does not exist, cannot delete module', { customerId, moduleId });
+        // Consider this a success as the module is effectively not there.
+        // Or, return a specific error/warning if this state is unexpected.
+        // For now, let's treat it as if the module is already deleted.
+        return success(undefined);
+      }
+
+      const initialModuleCount = customerConfig.modules.length;
+      customerConfig.modules = customerConfig.modules.filter(m => m.module_id !== moduleId);
+
+      if (customerConfig.modules.length === initialModuleCount) {
+        this.logger.warn('Module to delete was not found in customer configuration', { customerId, moduleId });
+        // Module was not found, effectively it's already "deleted" or never existed.
+        // Depending on desired strictness, this could be an error or a silent success.
+        // Returning success for idempotency.
+        return success(undefined);
+      }
+
+      // As with saveModuleConfig, saveCustomerConfig handles 'updatedAt'.
+      this.logger.debug('Attempting to save updated customer configuration after module deletion', { customerId, moduleId });
+      const saveResult = await this.saveCustomerConfig(customerConfig);
+
+      if (!saveResult.success) {
+        this.logger.error('Failed to save customer configuration after deleting module', {
+          customerId,
+          moduleId,
+          error: saveResult.error.message,
+        });
+        return failure(new Error(`Failed to save customer config after module deletion: ${saveResult.error.message}`));
+      }
+
+      this.logger.info('Module configuration deleted successfully by updating customer config', {
         customerId,
         moduleId,
-        error: error instanceof Error ? error.message : String(error),
       });
-
-      return failure(error instanceof Error ? error : new Error(String(error)));
+      return success(undefined);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error('Failed to delete module configuration', {
+        customerId,
+        moduleId,
+        error: errorMessage,
+        stack: error instanceof Error ? error.stack : undefined
+      });
+      return failure(error instanceof Error ? error : new Error(errorMessage));
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,6 +389,12 @@ importers:
       '@agent-desktop/types':
         specifier: workspace:*
         version: link:../types
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3.500.0
+        version: 3.823.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3.500.0
+        version: 3.823.0(@aws-sdk/client-dynamodb@3.823.0)
     devDependencies:
       '@types/jest':
         specifier: ^29.5.5
@@ -519,6 +525,487 @@ packages:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
     dev: true
+
+  /@aws-crypto/sha256-browser@5.2.0:
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.821.0
+      '@aws-sdk/util-locate-window': 3.804.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-crypto/sha256-js@5.2.0:
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.821.0
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-crypto/supports-web-crypto@5.2.0:
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-crypto/util@5.2.0:
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+    dependencies:
+      '@aws-sdk/types': 3.821.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/client-dynamodb@3.823.0:
+    resolution: {integrity: sha512-8FRUQb7BMyqP1yS32/Fzm7lIDgSyFjA5pVn9sRtWDfYraC4XQsJN7uVRIdMy69KrutxTI8VIaCtRpAdaYlhCGA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.823.0
+      '@aws-sdk/credential-provider-node': 3.823.0
+      '@aws-sdk/middleware-endpoint-discovery': 3.821.0
+      '@aws-sdk/middleware-host-header': 3.821.0
+      '@aws-sdk/middleware-logger': 3.821.0
+      '@aws-sdk/middleware-recursion-detection': 3.821.0
+      '@aws-sdk/middleware-user-agent': 3.823.0
+      '@aws-sdk/region-config-resolver': 3.821.0
+      '@aws-sdk/types': 3.821.0
+      '@aws-sdk/util-endpoints': 3.821.0
+      '@aws-sdk/util-user-agent-browser': 3.821.0
+      '@aws-sdk/util-user-agent-node': 3.823.0
+      '@smithy/config-resolver': 4.1.4
+      '@smithy/core': 3.5.2
+      '@smithy/fetch-http-handler': 5.0.4
+      '@smithy/hash-node': 4.0.4
+      '@smithy/invalid-dependency': 4.0.4
+      '@smithy/middleware-content-length': 4.0.4
+      '@smithy/middleware-endpoint': 4.1.10
+      '@smithy/middleware-retry': 4.1.11
+      '@smithy/middleware-serde': 4.0.8
+      '@smithy/middleware-stack': 4.0.4
+      '@smithy/node-config-provider': 4.1.3
+      '@smithy/node-http-handler': 4.0.6
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/smithy-client': 4.4.2
+      '@smithy/types': 4.3.1
+      '@smithy/url-parser': 4.0.4
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-body-length-node': 4.0.0
+      '@smithy/util-defaults-mode-browser': 4.0.18
+      '@smithy/util-defaults-mode-node': 4.0.18
+      '@smithy/util-endpoints': 3.0.6
+      '@smithy/util-middleware': 4.0.4
+      '@smithy/util-retry': 4.0.5
+      '@smithy/util-utf8': 4.0.0
+      '@smithy/util-waiter': 4.0.5
+      '@types/uuid': 9.0.8
+      tslib: 2.8.1
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/client-sso@3.823.0:
+    resolution: {integrity: sha512-dBWdsbyGw8rPfdCsZySNtTOGQK4EZ8lxB/CneSQWRBPHgQ+Ys88NXxImO8xfWO7Itt1eh8O7UDTZ9+smcvw2pw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.823.0
+      '@aws-sdk/middleware-host-header': 3.821.0
+      '@aws-sdk/middleware-logger': 3.821.0
+      '@aws-sdk/middleware-recursion-detection': 3.821.0
+      '@aws-sdk/middleware-user-agent': 3.823.0
+      '@aws-sdk/region-config-resolver': 3.821.0
+      '@aws-sdk/types': 3.821.0
+      '@aws-sdk/util-endpoints': 3.821.0
+      '@aws-sdk/util-user-agent-browser': 3.821.0
+      '@aws-sdk/util-user-agent-node': 3.823.0
+      '@smithy/config-resolver': 4.1.4
+      '@smithy/core': 3.5.2
+      '@smithy/fetch-http-handler': 5.0.4
+      '@smithy/hash-node': 4.0.4
+      '@smithy/invalid-dependency': 4.0.4
+      '@smithy/middleware-content-length': 4.0.4
+      '@smithy/middleware-endpoint': 4.1.10
+      '@smithy/middleware-retry': 4.1.11
+      '@smithy/middleware-serde': 4.0.8
+      '@smithy/middleware-stack': 4.0.4
+      '@smithy/node-config-provider': 4.1.3
+      '@smithy/node-http-handler': 4.0.6
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/smithy-client': 4.4.2
+      '@smithy/types': 4.3.1
+      '@smithy/url-parser': 4.0.4
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-body-length-node': 4.0.0
+      '@smithy/util-defaults-mode-browser': 4.0.18
+      '@smithy/util-defaults-mode-node': 4.0.18
+      '@smithy/util-endpoints': 3.0.6
+      '@smithy/util-middleware': 4.0.4
+      '@smithy/util-retry': 4.0.5
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/core@3.823.0:
+    resolution: {integrity: sha512-1Cf4w8J7wYexz0KU3zpaikHvldGXQEjFldHOhm0SBGRy7qfYNXecfJAamccF7RdgLxKGgkv5Pl9zX/Z/DcW9zg==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.821.0
+      '@aws-sdk/xml-builder': 3.821.0
+      '@smithy/core': 3.5.2
+      '@smithy/node-config-provider': 4.1.3
+      '@smithy/property-provider': 4.0.4
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/signature-v4': 5.1.2
+      '@smithy/smithy-client': 4.4.2
+      '@smithy/types': 4.3.1
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-middleware': 4.0.4
+      '@smithy/util-utf8': 4.0.0
+      fast-xml-parser: 4.4.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-env@3.823.0:
+    resolution: {integrity: sha512-AIrLLwumObge+U1klN4j5ToIozI+gE9NosENRyHe0GIIZgTLOG/8jxrMFVYFeNHs7RUtjDTxxewislhFyGxJ/w==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.823.0
+      '@aws-sdk/types': 3.821.0
+      '@smithy/property-provider': 4.0.4
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-http@3.823.0:
+    resolution: {integrity: sha512-u4DXvB/J/o2bcvP1JP6n3ch7V3/NngmiJFPsM0hKUyRlLuWM37HEDEdjPRs3/uL/soTxrEhWKTA9//YVkvzI0w==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.823.0
+      '@aws-sdk/types': 3.821.0
+      '@smithy/fetch-http-handler': 5.0.4
+      '@smithy/node-http-handler': 4.0.6
+      '@smithy/property-provider': 4.0.4
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/smithy-client': 4.4.2
+      '@smithy/types': 4.3.1
+      '@smithy/util-stream': 4.2.2
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-ini@3.823.0:
+    resolution: {integrity: sha512-C0o63qviK5yFvjH9zKWAnCUBkssJoQ1A1XAHe0IAQkurzoNBSmu9oVemqwnKKHA4H6QrmusaEERfL00yohIkJA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.823.0
+      '@aws-sdk/credential-provider-env': 3.823.0
+      '@aws-sdk/credential-provider-http': 3.823.0
+      '@aws-sdk/credential-provider-process': 3.823.0
+      '@aws-sdk/credential-provider-sso': 3.823.0
+      '@aws-sdk/credential-provider-web-identity': 3.823.0
+      '@aws-sdk/nested-clients': 3.823.0
+      '@aws-sdk/types': 3.821.0
+      '@smithy/credential-provider-imds': 4.0.6
+      '@smithy/property-provider': 4.0.4
+      '@smithy/shared-ini-file-loader': 4.0.4
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-node@3.823.0:
+    resolution: {integrity: sha512-nfSxXVuZ+2GJDpVFlflNfh55Yb4BtDsXLGNssXF5YU6UgSPsi8j2YkaE92Jv2s7dlUK07l0vRpLyPuXMaGeiRQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.823.0
+      '@aws-sdk/credential-provider-http': 3.823.0
+      '@aws-sdk/credential-provider-ini': 3.823.0
+      '@aws-sdk/credential-provider-process': 3.823.0
+      '@aws-sdk/credential-provider-sso': 3.823.0
+      '@aws-sdk/credential-provider-web-identity': 3.823.0
+      '@aws-sdk/types': 3.821.0
+      '@smithy/credential-provider-imds': 4.0.6
+      '@smithy/property-provider': 4.0.4
+      '@smithy/shared-ini-file-loader': 4.0.4
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-process@3.823.0:
+    resolution: {integrity: sha512-U/A10/7zu2FbMFFVpIw95y0TZf+oYyrhZTBn9eL8zgWcrYRqxrxdqtPj/zMrfIfyIvQUhuJSENN4dx4tfpCMWQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.823.0
+      '@aws-sdk/types': 3.821.0
+      '@smithy/property-provider': 4.0.4
+      '@smithy/shared-ini-file-loader': 4.0.4
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/credential-provider-sso@3.823.0:
+    resolution: {integrity: sha512-ff8IM80Wqz1V7VVMaMUqO2iR417jggfGWLPl8j2l7uCgwpEyop1ZZl5CFVYEwSupRBtwp+VlW1gTCk7ke56MUw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-sdk/client-sso': 3.823.0
+      '@aws-sdk/core': 3.823.0
+      '@aws-sdk/token-providers': 3.823.0
+      '@aws-sdk/types': 3.821.0
+      '@smithy/property-provider': 4.0.4
+      '@smithy/shared-ini-file-loader': 4.0.4
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-web-identity@3.823.0:
+    resolution: {integrity: sha512-lzoZdJMQq9w7i4lXVka30cVBe/dZoUDZST8Xz/soEd73gg7RTKgG+0szL4xFWgdBDgcJDWLfZfJzlbyIVyAyOA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.823.0
+      '@aws-sdk/nested-clients': 3.823.0
+      '@aws-sdk/types': 3.821.0
+      '@smithy/property-provider': 4.0.4
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/endpoint-cache@3.804.0:
+    resolution: {integrity: sha512-TQVDkA/lV6ua75ELZaichMzlp6x7tDa1bqdy/+0ZftmODPtKXuOOEcJxmdN7Ui/YRo1gkRz2D9txYy7IlNg1Og==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      mnemonist: 0.38.3
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/lib-dynamodb@3.823.0(@aws-sdk/client-dynamodb@3.823.0):
+    resolution: {integrity: sha512-sy2PR9MbppKRuydWXwy6MrgUlLSjLl/NbQgZbHVqzpAgAQPy36QhvXXZQyY9Y+b6j7tNLarDpC4Q5dgUycwRVg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-dynamodb': ^3.823.0
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.823.0
+      '@aws-sdk/core': 3.823.0
+      '@aws-sdk/util-dynamodb': 3.823.0(@aws-sdk/client-dynamodb@3.823.0)
+      '@smithy/core': 3.5.2
+      '@smithy/smithy-client': 4.4.2
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/middleware-endpoint-discovery@3.821.0:
+    resolution: {integrity: sha512-8EguERzvpzTN2WrPaspK/F9GSkAzBQbecgIaCL49rJWKAso+ewmVVPnrXGzbeGVXTk4G0XuWSjt8wqUzZyt7wQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-sdk/endpoint-cache': 3.804.0
+      '@aws-sdk/types': 3.821.0
+      '@smithy/node-config-provider': 4.1.3
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/middleware-host-header@3.821.0:
+    resolution: {integrity: sha512-xSMR+sopSeWGx5/4pAGhhfMvGBHioVBbqGvDs6pG64xfNwM5vq5s5v6D04e2i+uSTj4qGa71dLUs5I0UzAK3sw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.821.0
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/middleware-logger@3.821.0:
+    resolution: {integrity: sha512-0cvI0ipf2tGx7fXYEEN5fBeZDz2RnHyb9xftSgUsEq7NBxjV0yTZfLJw6Za5rjE6snC80dRN8+bTNR1tuG89zA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.821.0
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/middleware-recursion-detection@3.821.0:
+    resolution: {integrity: sha512-efmaifbhBoqKG3bAoEfDdcM8hn1psF+4qa7ykWuYmfmah59JBeqHLfz5W9m9JoTwoKPkFcVLWZxnyZzAnVBOIg==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.821.0
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/middleware-user-agent@3.823.0:
+    resolution: {integrity: sha512-TKRQK09ld1LrIPExC9rIDpqnMsWcv+eq8ABKFHVo8mDLTSuWx/IiQ4eCh9T5zDuEZcLY4nNYCSzXKqw6XKcMCA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.823.0
+      '@aws-sdk/types': 3.821.0
+      '@aws-sdk/util-endpoints': 3.821.0
+      '@smithy/core': 3.5.2
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/nested-clients@3.823.0:
+    resolution: {integrity: sha512-/BcyOBubrJnd2gxlbbmNJR1w0Z3OVN/UE8Yz20e+ou+Mijjv7EbtVwmWvio1e3ZjphwdA8tVfPYZKwXmrvHKmQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.823.0
+      '@aws-sdk/middleware-host-header': 3.821.0
+      '@aws-sdk/middleware-logger': 3.821.0
+      '@aws-sdk/middleware-recursion-detection': 3.821.0
+      '@aws-sdk/middleware-user-agent': 3.823.0
+      '@aws-sdk/region-config-resolver': 3.821.0
+      '@aws-sdk/types': 3.821.0
+      '@aws-sdk/util-endpoints': 3.821.0
+      '@aws-sdk/util-user-agent-browser': 3.821.0
+      '@aws-sdk/util-user-agent-node': 3.823.0
+      '@smithy/config-resolver': 4.1.4
+      '@smithy/core': 3.5.2
+      '@smithy/fetch-http-handler': 5.0.4
+      '@smithy/hash-node': 4.0.4
+      '@smithy/invalid-dependency': 4.0.4
+      '@smithy/middleware-content-length': 4.0.4
+      '@smithy/middleware-endpoint': 4.1.10
+      '@smithy/middleware-retry': 4.1.11
+      '@smithy/middleware-serde': 4.0.8
+      '@smithy/middleware-stack': 4.0.4
+      '@smithy/node-config-provider': 4.1.3
+      '@smithy/node-http-handler': 4.0.6
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/smithy-client': 4.4.2
+      '@smithy/types': 4.3.1
+      '@smithy/url-parser': 4.0.4
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-body-length-node': 4.0.0
+      '@smithy/util-defaults-mode-browser': 4.0.18
+      '@smithy/util-defaults-mode-node': 4.0.18
+      '@smithy/util-endpoints': 3.0.6
+      '@smithy/util-middleware': 4.0.4
+      '@smithy/util-retry': 4.0.5
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/region-config-resolver@3.821.0:
+    resolution: {integrity: sha512-t8og+lRCIIy5nlId0bScNpCkif8sc0LhmtaKsbm0ZPm3sCa/WhCbSZibjbZ28FNjVCV+p0D9RYZx0VDDbtWyjw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.821.0
+      '@smithy/node-config-provider': 4.1.3
+      '@smithy/types': 4.3.1
+      '@smithy/util-config-provider': 4.0.0
+      '@smithy/util-middleware': 4.0.4
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/token-providers@3.823.0:
+    resolution: {integrity: sha512-vz6onCb/+g4y+owxGGPMEMdN789dTfBOgz/c9pFv0f01840w9Rrt46l+gjQlnXnx+0KG6wNeBIVhFdbCfV3HyQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-sdk/core': 3.823.0
+      '@aws-sdk/nested-clients': 3.823.0
+      '@aws-sdk/types': 3.821.0
+      '@smithy/property-provider': 4.0.4
+      '@smithy/shared-ini-file-loader': 4.0.4
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/types@3.821.0:
+    resolution: {integrity: sha512-Znroqdai1a90TlxGaJ+FK1lwC0fHpo97Xjsp5UKGR5JODYm7f9+/fF17ebO1KdoBr/Rm0UIFiF5VmI8ts9F1eA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/util-dynamodb@3.823.0(@aws-sdk/client-dynamodb@3.823.0):
+    resolution: {integrity: sha512-a5lCasQFCKaTIXjMaBK7CuLK8LpIFHafAqKkYOPmdWvIyQcbYHZBtyBDMMpb9qQLMwy2WIYWmDx2EbWj3aKPeQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-dynamodb': ^3.823.0
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.823.0
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/util-endpoints@3.821.0:
+    resolution: {integrity: sha512-Uknt/zUZnLE76zaAAPEayOeF5/4IZ2puTFXvcSCWHsi9m3tqbb9UozlnlVqvCZLCRWfQryZQoG2W4XSS3qgk5A==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.821.0
+      '@smithy/types': 4.3.1
+      '@smithy/util-endpoints': 3.0.6
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/util-locate-window@3.804.0:
+    resolution: {integrity: sha512-zVoRfpmBVPodYlnMjgVjfGoEZagyRF5IPn3Uo6ZvOZp24chnW/FRstH7ESDHDDRga4z3V+ElUQHKpFDXWyBW5A==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/util-user-agent-browser@3.821.0:
+    resolution: {integrity: sha512-irWZHyM0Jr1xhC+38OuZ7JB6OXMLPZlj48thElpsO1ZSLRkLZx5+I7VV6k3sp2yZ7BYbKz/G2ojSv4wdm7XTLw==}
+    dependencies:
+      '@aws-sdk/types': 3.821.0
+      '@smithy/types': 4.3.1
+      bowser: 2.11.0
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/util-user-agent-node@3.823.0:
+    resolution: {integrity: sha512-WvNeRz7HV3JLBVGTXW4Qr5QvvWY0vtggH5jW/NqHFH+ZEliVQaUIJ/HNLMpMoCSiu/DlpQAyAjRZXAptJ0oqbw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.823.0
+      '@aws-sdk/types': 3.821.0
+      '@smithy/node-config-provider': 4.1.3
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@aws-sdk/xml-builder@3.821.0:
+    resolution: {integrity: sha512-DIIotRnefVL6DiaHtO6/21DhJ4JZnnIwdNbpwiAhdt/AVbttcE4yw925gsjur0OGv5BTYXQXU3YnANBYnZjuQA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
 
   /@babel/code-frame@7.27.1:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -3436,6 +3923,410 @@ packages:
       '@sinonjs/commons': 3.0.1
     dev: true
 
+  /@smithy/abort-controller@4.0.4:
+    resolution: {integrity: sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/config-resolver@4.1.4:
+    resolution: {integrity: sha512-prmU+rDddxHOH0oNcwemL+SwnzcG65sBF2yXRO7aeXIn/xTlq2pX7JLVbkBnVLowHLg4/OL4+jBmv9hVrVGS+w==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 4.1.3
+      '@smithy/types': 4.3.1
+      '@smithy/util-config-provider': 4.0.0
+      '@smithy/util-middleware': 4.0.4
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/core@3.5.2:
+    resolution: {integrity: sha512-mKItSybuNu1aq5ZpA5G5c7VF9gKqxXwTWlaJxmVyzLmUaBaLotanz2vBt3uPj7yYpCMQ9zETiQ0bT43WLSIS9w==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/middleware-serde': 4.0.8
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/types': 4.3.1
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-middleware': 4.0.4
+      '@smithy/util-stream': 4.2.2
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/credential-provider-imds@4.0.6:
+    resolution: {integrity: sha512-hKMWcANhUiNbCJouYkZ9V3+/Qf9pteR1dnwgdyzR09R4ODEYx8BbUysHwRSyex4rZ9zapddZhLFTnT4ZijR4pw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 4.1.3
+      '@smithy/property-provider': 4.0.4
+      '@smithy/types': 4.3.1
+      '@smithy/url-parser': 4.0.4
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/fetch-http-handler@5.0.4:
+    resolution: {integrity: sha512-AMtBR5pHppYMVD7z7G+OlHHAcgAN7v0kVKEpHuTO4Gb199Gowh0taYi9oDStFeUhetkeP55JLSVlTW1n9rFtUw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/querystring-builder': 4.0.4
+      '@smithy/types': 4.3.1
+      '@smithy/util-base64': 4.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/hash-node@4.0.4:
+    resolution: {integrity: sha512-qnbTPUhCVnCgBp4z4BUJUhOEkVwxiEi1cyFM+Zj6o+aY8OFGxUQleKWq8ltgp3dujuhXojIvJWdoqpm6dVO3lQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.3.1
+      '@smithy/util-buffer-from': 4.0.0
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/invalid-dependency@4.0.4:
+    resolution: {integrity: sha512-bNYMi7WKTJHu0gn26wg8OscncTt1t2b8KcsZxvOv56XA6cyXtOAAAaNP7+m45xfppXfOatXF3Sb1MNsLUgVLTw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/is-array-buffer@2.2.0:
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/is-array-buffer@4.0.0:
+    resolution: {integrity: sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/middleware-content-length@4.0.4:
+    resolution: {integrity: sha512-F7gDyfI2BB1Kc+4M6rpuOLne5LOcEknH1n6UQB69qv+HucXBR1rkzXBnQTB2q46sFy1PM/zuSJOB532yc8bg3w==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/middleware-endpoint@4.1.10:
+    resolution: {integrity: sha512-fcW5UNrN152gXMyr4ZnxzAWNk+C+fnEiIhyq4W9nzAwAv1rjM9/yPi9WLXrGXYMLCQQi/WNi0YyxDkR7fOv+Hw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/core': 3.5.2
+      '@smithy/middleware-serde': 4.0.8
+      '@smithy/node-config-provider': 4.1.3
+      '@smithy/shared-ini-file-loader': 4.0.4
+      '@smithy/types': 4.3.1
+      '@smithy/url-parser': 4.0.4
+      '@smithy/util-middleware': 4.0.4
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/middleware-retry@4.1.11:
+    resolution: {integrity: sha512-96dxi6ExvZaH3VZ/MbQuXY2674IlTxkuEHWKMgmT6ZoR613rxhUKKgf3U/guMnLHdk0FFOEl+upSLvM7sTtPRQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 4.1.3
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/service-error-classification': 4.0.5
+      '@smithy/smithy-client': 4.4.2
+      '@smithy/types': 4.3.1
+      '@smithy/util-middleware': 4.0.4
+      '@smithy/util-retry': 4.0.5
+      tslib: 2.8.1
+      uuid: 9.0.1
+    dev: false
+
+  /@smithy/middleware-serde@4.0.8:
+    resolution: {integrity: sha512-iSSl7HJoJaGyMIoNn2B7czghOVwJ9nD7TMvLhMWeSB5vt0TnEYyRRqPJu/TqW76WScaNvYYB8nRoiBHR9S1Ddw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/middleware-stack@4.0.4:
+    resolution: {integrity: sha512-kagK5ggDrBUCCzI93ft6DjteNSfY8Ulr83UtySog/h09lTIOAJ/xUSObutanlPT0nhoHAkpmW9V5K8oPyLh+QA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/node-config-provider@4.1.3:
+    resolution: {integrity: sha512-HGHQr2s59qaU1lrVH6MbLlmOBxadtzTsoO4c+bF5asdgVik3I8o7JIOzoeqWc5MjVa+vD36/LWE0iXKpNqooRw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/property-provider': 4.0.4
+      '@smithy/shared-ini-file-loader': 4.0.4
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/node-http-handler@4.0.6:
+    resolution: {integrity: sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/abort-controller': 4.0.4
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/querystring-builder': 4.0.4
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/property-provider@4.0.4:
+    resolution: {integrity: sha512-qHJ2sSgu4FqF4U/5UUp4DhXNmdTrgmoAai6oQiM+c5RZ/sbDwJ12qxB1M6FnP+Tn/ggkPZf9ccn4jqKSINaquw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/protocol-http@5.1.2:
+    resolution: {integrity: sha512-rOG5cNLBXovxIrICSBm95dLqzfvxjEmuZx4KK3hWwPFHGdW3lxY0fZNXfv2zebfRO7sJZ5pKJYHScsqopeIWtQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/querystring-builder@4.0.4:
+    resolution: {integrity: sha512-SwREZcDnEYoh9tLNgMbpop+UTGq44Hl9tdj3rf+yeLcfH7+J8OXEBaMc2kDxtyRHu8BhSg9ADEx0gFHvpJgU8w==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.3.1
+      '@smithy/util-uri-escape': 4.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/querystring-parser@4.0.4:
+    resolution: {integrity: sha512-6yZf53i/qB8gRHH/l2ZwUG5xgkPgQF15/KxH0DdXMDHjesA9MeZje/853ifkSY0x4m5S+dfDZ+c4x439PF0M2w==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/service-error-classification@4.0.5:
+    resolution: {integrity: sha512-LvcfhrnCBvCmTee81pRlh1F39yTS/+kYleVeLCwNtkY8wtGg8V/ca9rbZZvYIl8OjlMtL6KIjaiL/lgVqHD2nA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.3.1
+    dev: false
+
+  /@smithy/shared-ini-file-loader@4.0.4:
+    resolution: {integrity: sha512-63X0260LoFBjrHifPDs+nM9tV0VMkOTl4JRMYNuKh/f5PauSjowTfvF3LogfkWdcPoxsA9UjqEOgjeYIbhb7Nw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/signature-v4@5.1.2:
+    resolution: {integrity: sha512-d3+U/VpX7a60seHziWnVZOHuEgJlclufjkS6zhXvxcJgkJq4UWdH5eOBLzHRMx6gXjsdT9h6lfpmLzbrdupHgQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/is-array-buffer': 4.0.0
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/types': 4.3.1
+      '@smithy/util-hex-encoding': 4.0.0
+      '@smithy/util-middleware': 4.0.4
+      '@smithy/util-uri-escape': 4.0.0
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/smithy-client@4.4.2:
+    resolution: {integrity: sha512-4HIfWatRbttWLigQuNHWED1ZppUelBySaHt1rTeYw9D/2orbmelfz4XVNPgAmfyZ7DZ15sExBXzEY9HcpVyjow==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/core': 3.5.2
+      '@smithy/middleware-endpoint': 4.1.10
+      '@smithy/middleware-stack': 4.0.4
+      '@smithy/protocol-http': 5.1.2
+      '@smithy/types': 4.3.1
+      '@smithy/util-stream': 4.2.2
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/types@4.3.1:
+    resolution: {integrity: sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/url-parser@4.0.4:
+    resolution: {integrity: sha512-eMkc144MuN7B0TDA4U2fKs+BqczVbk3W+qIvcoCY6D1JY3hnAdCuhCZODC+GAeaxj0p6Jroz4+XMUn3PCxQQeQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/querystring-parser': 4.0.4
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-base64@4.0.0:
+    resolution: {integrity: sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/util-buffer-from': 4.0.0
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-body-length-browser@4.0.0:
+    resolution: {integrity: sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-body-length-node@4.0.0:
+    resolution: {integrity: sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-buffer-from@2.2.0:
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-buffer-from@4.0.0:
+    resolution: {integrity: sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/is-array-buffer': 4.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-config-provider@4.0.0:
+    resolution: {integrity: sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-defaults-mode-browser@4.0.18:
+    resolution: {integrity: sha512-rZizM77/c10ZNHrlymKCngMOmqkFkzqCX5MNbEm6jq+Rn6M3un9vCYJlpiGlDM0/21EsY5nZpw4b9hvQWXTxgQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/property-provider': 4.0.4
+      '@smithy/smithy-client': 4.4.2
+      '@smithy/types': 4.3.1
+      bowser: 2.11.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-defaults-mode-node@4.0.18:
+    resolution: {integrity: sha512-c9dk4NBQffyktJLo01vlIzzjSPUA82KlBXeRmYcCumz8F8u3gs0PaEqSeTdEeXQfYq3WUuqq35TxQgvqNQF7Xw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/config-resolver': 4.1.4
+      '@smithy/credential-provider-imds': 4.0.6
+      '@smithy/node-config-provider': 4.1.3
+      '@smithy/property-provider': 4.0.4
+      '@smithy/smithy-client': 4.4.2
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-endpoints@3.0.6:
+    resolution: {integrity: sha512-YARl3tFL3WgPuLzljRUnrS2ngLiUtkwhQtj8PAL13XZSyUiNLQxwG3fBBq3QXFqGFUXepIN73pINp3y8c2nBmA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 4.1.3
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-hex-encoding@4.0.0:
+    resolution: {integrity: sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-middleware@4.0.4:
+    resolution: {integrity: sha512-9MLKmkBmf4PRb0ONJikCbCwORACcil6gUWojwARCClT7RmLzF04hUR4WdRprIXal7XVyrddadYNfp2eF3nrvtQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-retry@4.0.5:
+    resolution: {integrity: sha512-V7MSjVDTlEt/plmOFBn1762Dyu5uqMrV2Pl2X0dYk4XvWfdWJNe9Bs5Bzb56wkCuiWjSfClVMGcsuKrGj7S/yg==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/service-error-classification': 4.0.5
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-stream@4.2.2:
+    resolution: {integrity: sha512-aI+GLi7MJoVxg24/3J1ipwLoYzgkB4kUfogZfnslcYlynj3xsQ0e7vk4TnTro9hhsS5PvX1mwmkRqqHQjwcU7w==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/fetch-http-handler': 5.0.4
+      '@smithy/node-http-handler': 4.0.6
+      '@smithy/types': 4.3.1
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-buffer-from': 4.0.0
+      '@smithy/util-hex-encoding': 4.0.0
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-uri-escape@4.0.0:
+    resolution: {integrity: sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-utf8@2.3.0:
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-utf8@4.0.0:
+    resolution: {integrity: sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/util-buffer-from': 4.0.0
+      tslib: 2.8.1
+    dev: false
+
+  /@smithy/util-waiter@4.0.5:
+    resolution: {integrity: sha512-4QvC49HTteI1gfemu0I1syWovJgPvGn7CVUoN9ZFkdvr/cCFkrEL7qNCdx/2eICqDWEGnnr68oMdSIPCLAriSQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@smithy/abort-controller': 4.0.4
+      '@smithy/types': 4.3.1
+      tslib: 2.8.1
+    dev: false
+
   /@socket.io/component-emitter@3.1.2:
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
     dev: false
@@ -4063,6 +4954,10 @@ packages:
   /@types/tough-cookie@4.0.5:
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
     dev: true
+
+  /@types/uuid@9.0.8:
+    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
+    dev: false
 
   /@types/yargs-parser@21.0.3:
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -4902,6 +5797,10 @@ packages:
   /boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
     dev: true
+
+  /bowser@2.11.0:
+    resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
+    dev: false
 
   /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -6240,6 +7139,13 @@ packages:
   /fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
     dev: true
+
+  /fast-xml-parser@4.4.1:
+    resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
+    hasBin: true
+    dependencies:
+      strnum: 1.1.2
+    dev: false
 
   /fastest-stable-stringify@2.0.2:
     resolution: {integrity: sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==}
@@ -7982,6 +8888,12 @@ packages:
       ufo: 1.6.1
     dev: true
 
+  /mnemonist@0.38.3:
+    resolution: {integrity: sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==}
+    dependencies:
+      obliterator: 1.6.1
+    dev: false
+
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -8214,6 +9126,10 @@ packages:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
     dev: true
+
+  /obliterator@1.6.1:
+    resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
+    dev: false
 
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -9423,6 +10339,10 @@ packages:
       js-tokens: 9.0.1
     dev: true
 
+  /strnum@1.1.2:
+    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
+    dev: false
+
   /strong-log-transformer@2.1.0:
     resolution: {integrity: sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==}
     engines: {node: '>=4'}
@@ -9972,6 +10892,11 @@ packages:
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+    dev: false
 
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}


### PR DESCRIPTION
This replaces the mock implementation of DynamoDBConfigStore with a functional version using AWS SDK v3.

Key changes:
- Added AWS SDK v3 dependencies: `@aws-sdk/client-dynamodb` and `@aws-sdk/lib-dynamodb`.
- Initialized `DynamoDBDocumentClient` in the constructor.
- Implemented `getCustomerConfig` using `GetCommand`.
- Implemented `saveCustomerConfig` using `PutCommand`.
- Implemented `deleteCustomerConfig` using `DeleteCommand`.
- Implemented `listCustomerConfigs` using `ScanCommand`.
- Refactored `getModuleConfig`, `saveModuleConfig`, and `deleteModuleConfig` to utilize the new DynamoDB-backed customer methods.
- Included error handling and logging for all methods.

Next, I'll focus on adding comprehensive unit tests for the DynamoDBConfigStore.