### PR TITLE
Fix Jest library path mapping

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -4,7 +4,7 @@ module.exports = {
   ...nxPreset,
   testEnvironment: 'jsdom',
   moduleNameMapper: {
-    '^@agent-desktop/(.*)$': '<rootDir>/libs/$1/src',
+    '^@agent-desktop/(.*)$': '<rootDir>/../../libs/$1/src',
   },
   collectCoverageFrom: [
     'libs/**/*.{ts,tsx}',


### PR DESCRIPTION
## Summary
- ensure Jest presets resolve libraries correctly with `../../` prefix

## Testing
- `pnpm install`
- `npx nx test logging` *(fails: Cannot find module 'tslib' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6840768f6e248323af0b48343a2f2215