### PR TITLE
Fix LogLevel imports

### DIFF
--- a/libs/logging/jest.config.ts
+++ b/libs/logging/jest.config.ts
@@ -6,8 +6,12 @@ module.exports = {
   transform: {
     '^.+\\.[tj]s$': [
       'ts-jest',
-      { tsconfig: '<rootDir>/tsconfig.spec.json' },
+      { tsconfig: '<rootDir>/tsconfig.spec.json', isolatedModules: true },
     ],
+  },
+  moduleNameMapper: {
+    '^@agent-desktop/types$': '<rootDir>/test-types.ts',
+    '^@agent-desktop/(.*)$': '<rootDir>/../../libs/$1/src',
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/libs/logging',

--- a/libs/logging/src/logger-factory.spec.ts
+++ b/libs/logging/src/logger-factory.spec.ts
@@ -3,7 +3,7 @@
  */
 
 // Import LogLevel from types library
-const { LogLevel } = require('@agent-desktop/types');
+import { LogLevel } from '@agent-desktop/types';
 import { LoggerFactory, createLogger, getLogger } from './logger-factory';
 import { Logger } from './logger';
 

--- a/libs/logging/src/logger-factory.ts
+++ b/libs/logging/src/logger-factory.ts
@@ -3,7 +3,7 @@
  * @module @agent-desktop/logging
  */
 
-import type { LogLevel, LogTransport } from '@agent-desktop/types';
+import { LogLevel, type LogTransport } from '@agent-desktop/types';
 import { Logger, type LoggerConfig } from './logger';
 import { ConsoleTransport, FileTransport, CloudWatchTransport } from './transports';
 

--- a/libs/logging/src/logger.spec.ts
+++ b/libs/logging/src/logger.spec.ts
@@ -3,7 +3,7 @@
  */
 
 // Import LogLevel from types library
-const { LogLevel } = require('@agent-desktop/types');
+import { LogLevel } from '@agent-desktop/types';
 import { Logger } from './logger';
 
 describe('Logger', () => {

--- a/libs/logging/src/logger.ts
+++ b/libs/logging/src/logger.ts
@@ -3,13 +3,13 @@
  * @module @agent-desktop/logging
  */
 
-import type {
+import {
   LogLevel,
-  LogEntry,
-  LogTransport,
-  CorrelationContext,
-  PerformanceMetrics,
-  ErrorInfo,
+  type LogEntry,
+  type LogTransport,
+  type CorrelationContext,
+  type PerformanceMetrics,
+  type ErrorInfo,
 } from '@agent-desktop/types';
 
 /**

--- a/libs/logging/src/transports/console.transport.spec.ts
+++ b/libs/logging/src/transports/console.transport.spec.ts
@@ -3,7 +3,7 @@
  */
 
 // Import LogLevel from types library
-const { LogLevel } = require('@agent-desktop/types');
+import { LogLevel } from '@agent-desktop/types';
 import { ConsoleTransport } from './console.transport';
 
 describe('ConsoleTransport', () => {

--- a/libs/logging/src/transports/console.transport.ts
+++ b/libs/logging/src/transports/console.transport.ts
@@ -3,7 +3,7 @@
  * @module @agent-desktop/logging/transports
  */
 
-import type { LogLevel, LogEntry, LogTransport } from '@agent-desktop/types';
+import { LogLevel, type LogEntry, type LogTransport } from '@agent-desktop/types';
 
 /**
  * Console transport configuration

--- a/libs/logging/test-types.ts
+++ b/libs/logging/test-types.ts
@@ -1,0 +1,7 @@
+export enum LogLevel {
+  DEBUG = 0,
+  INFO = 1,
+  WARN = 2,
+  ERROR = 3,
+  FATAL = 4,
+}

--- a/libs/types/src/core/config.types.ts
+++ b/libs/types/src/core/config.types.ts
@@ -11,7 +11,7 @@ export type Environment = 'development' | 'staging' | 'production';
 /**
  * Log level configuration
  */
-export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+export type ConfigLogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 
 /**
  * VDI platform types supported by the application
@@ -39,7 +39,7 @@ export interface BaseConfig {
  */
 export interface AppConfig extends BaseConfig {
   readonly environment: Environment;
-  readonly logLevel: LogLevel;
+  readonly logLevel: ConfigLogLevel;
   readonly apiEndpoint: string;
   readonly websocketEndpoint: string;
   readonly maxRetryAttempts: number;


### PR DESCRIPTION
## Summary
- convert `require` to `import` in logger-related tests
- adjust logging library to import `LogLevel` as a value
- stub `@agent-desktop/types` for tests
- rename config type to avoid enum conflict
- update Jest config for isolated modules

## Testing
- `pnpm exec nx test logging`

------
https://chatgpt.com/codex/tasks/task_e_68407692b9688323b5a938f54945689d