### PR TITLE
Implement queue size limit for ConfigWebSocketService

### DIFF
--- a/libs/config/src/config.service.ts
+++ b/libs/config/src/config.service.ts
@@ -78,6 +78,7 @@ export interface ConfigServiceOptions {
     readonly url?: string;
     readonly reconnectInterval?: number;
     readonly maxReconnectAttempts?: number;
+    readonly maxQueueSize?: number;
   };
   readonly storeType: 'memory' | 'dynamodb';
   readonly dynamoTableName?: string;

--- a/libs/config/src/config.websocket.spec.ts
+++ b/libs/config/src/config.websocket.spec.ts
@@ -1,0 +1,39 @@
+import { ConfigWebSocketService } from './config.websocket';
+import { ConfigSource, type ConfigChangeEvent } from './config.service';
+
+describe('ConfigWebSocketService queue', () => {
+  const mockLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    createChild: jest.fn().mockReturnThis(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should drop oldest messages when queue limit is reached', () => {
+    const service: any = new ConfigWebSocketService({ maxQueueSize: 2 }, mockLogger as any);
+
+    const createEvent = (key: string): ConfigChangeEvent => ({
+      key,
+      oldValue: null,
+      newValue: key,
+      source: ConfigSource.OVERRIDE,
+      timestamp: new Date(),
+    });
+
+    service.notifyConfigChange('cust', createEvent('k1'));
+    service.notifyConfigChange('cust', createEvent('k2'));
+    service.notifyConfigChange('cust', createEvent('k3'));
+    service.notifyConfigChange('cust', createEvent('k4'));
+
+    const queue = service.messageQueue as any[];
+    const keys = queue.map(m => (m.payload as any).change.key);
+    expect(queue.length).toBe(2);
+    expect(keys).toEqual(['k3', 'k4']);
+    expect(mockLogger.warn).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add `maxQueueSize` to `WebSocketOptions`
- drop oldest queued messages when the limit is reached
- warn when dropping messages
- allow specifying queue size from `ConfigServiceOptions`
- test queue size enforcement

## Testing
- `pnpm exec nx test config --verbose` *(fails: Test suite failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_68408590de548323b9758d4ebd8741a9