### PR TITLE
Validate WebSocket queue size

### DIFF
--- a/libs/config/src/config.websocket.spec.ts
+++ b/libs/config/src/config.websocket.spec.ts
@@ -36,4 +36,13 @@ describe('ConfigWebSocketService queue', () => {
     expect(keys).toEqual(['k3', 'k4']);
     expect(mockLogger.warn).toHaveBeenCalledTimes(2);
   });
+
+  it('should fallback to default queue size when provided value is invalid', () => {
+    const service: any = new ConfigWebSocketService({ maxQueueSize: 0 }, mockLogger as any);
+    expect(service.maxQueueSize).toBe(100);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'Invalid maxQueueSize provided, using default value',
+      expect.objectContaining({ maxQueueSize: 0 })
+    );
+  });
 });

--- a/libs/config/src/config.websocket.ts
+++ b/libs/config/src/config.websocket.ts
@@ -85,8 +85,20 @@ export class ConfigWebSocketService {
   private isConnected = false;
 
   constructor(options: Partial<WebSocketOptions> = {}, logger?: Logger) {
-    this.options = { ...DEFAULT_WEBSOCKET_OPTIONS, ...options };
+    const mergedOptions = { ...DEFAULT_WEBSOCKET_OPTIONS, ...options };
+    if (!Number.isInteger(mergedOptions.maxQueueSize) || mergedOptions.maxQueueSize <= 0) {
+      logger?.warn?.('Invalid maxQueueSize provided, using default value', {
+        maxQueueSize: mergedOptions.maxQueueSize,
+      });
+      console.warn('[ConfigWebSocketService] Invalid maxQueueSize provided, using default value', {
+        maxQueueSize: mergedOptions.maxQueueSize,
+      });
+      mergedOptions.maxQueueSize = DEFAULT_WEBSOCKET_OPTIONS.maxQueueSize;
+    }
+
+    this.options = mergedOptions;
     this.maxQueueSize = this.options.maxQueueSize;
+
     if (logger) {
       this.logger = logger.createChild('ConfigWebSocketService');
     } else {


### PR DESCRIPTION
## Summary
- validate `maxQueueSize` during construction of `ConfigWebSocketService`
- use default queue size when invalid value provided
- test fallback logic for bad queue size

## Testing
- `npx -y jest -c libs/config/jest.config.ts libs/config/src/config.websocket.spec.ts` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840895f67bc8323bdd0fe7c25832642