### PR TITLE
Fix ConfigChangeEvent in module registry tests

### DIFF
--- a/libs/core/src/module-registry.spec.ts
+++ b/libs/core/src/module-registry.spec.ts
@@ -13,7 +13,7 @@ import {
   type ModuleMetadata,
   type IModule,
 } from './base-module';
-import { ConfigService } from '@agent-desktop/config';
+import { ConfigService, ConfigSource } from '@agent-desktop/config';
 import { createLogger } from '@agent-desktop/logging';
 import type { CustomerID, ModuleID, ModuleConfig } from '@agent-desktop/types';
 
@@ -586,6 +586,8 @@ describe('ModuleRegistry', () => {
         key: 'modules.test-module.enabled',
         newValue: false,
         oldValue: true,
+        source: ConfigSource.OVERRIDE,
+        timestamp: new Date(),
       });
       
       expect(mockLogger.info).toHaveBeenCalledWith(
@@ -626,6 +628,8 @@ describe('ModuleRegistry', () => {
         key: 'modules.test-module.position',
         newValue: 'sidebar',
         oldValue: 'main',
+        source: ConfigSource.OVERRIDE,
+        timestamp: new Date(),
       });
 
       expect(mockLogger.warn).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- ensure config watchers in tests provide `source` and `timestamp`

## Testing
- `pnpm test` *(fails: nx not found or other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840925b31bc8323b70dd1de6487da95