### PR TITLE
fix(types): re-export branded utility types

### DIFF
--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -57,3 +57,11 @@ export {
   success,
   failure,
 } from './utils/common.types';
+
+// Re-export branded utility types
+export type {
+  UUID,
+  Email,
+  PhoneNumber,
+  // include other branded types if desired
+} from './utils/common.types';


### PR DESCRIPTION
## Summary
- re-export `UUID`, `Email`, and `PhoneNumber` from `libs/types/src/utils/common.types`

## Testing
- `pnpm nx test types`

------
https://chatgpt.com/codex/tasks/task_e_68409f0106288323bd1a2f242d05b8ab