### PR TITLE
Implement branding API integration

### DIFF
--- a/apps/ccp-admin/src/services/api/assets.api.ts
+++ b/apps/ccp-admin/src/services/api/assets.api.ts
@@ -1,0 +1,20 @@
+import { BaseAPIService } from './base.api';
+
+export interface AssetUploadResult {
+  url: string;
+}
+
+export class AssetsAPIService extends BaseAPIService {
+  private readonly baseEndpoint = '/assets';
+
+  async uploadAsset(file: File): Promise<AssetUploadResult> {
+    const form = new FormData();
+    form.append('file', file);
+    return this.post<AssetUploadResult>(`${this.baseEndpoint}/upload`, form, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+      timeout: 30000,
+    });
+  }
+}
+
+export const assetsAPI = new AssetsAPIService();

--- a/apps/ccp-admin/src/services/api/index.ts
+++ b/apps/ccp-admin/src/services/api/index.ts
@@ -8,3 +8,4 @@ export { CustomerAPIService } from './customers.api';
 export { ModuleAPIService } from './modules.api';
 export { AnalyticsAPIService } from './analytics.api';
 export { BrandingAPIService } from './branding.api';
+export { AssetsAPIService } from './assets.api';

--- a/apps/ccp-admin/src/services/queries/__tests__/branding.queries.test.tsx
+++ b/apps/ccp-admin/src/services/queries/__tests__/branding.queries.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview Tests for branding query hooks
+ */
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useUploadAsset } from '../branding.queries';
+import { assetsAPI } from '../../api/assets.api';
+
+jest.mock('../../api/assets.api');
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe('branding query hooks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uploads asset successfully', async () => {
+    (assetsAPI.uploadAsset as jest.Mock).mockResolvedValue({ url: 's3://logo.png' });
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useUploadAsset(), { wrapper });
+    act(() => {
+      result.current.mutate({ file: new File(['a'], 'logo.png') });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.url).toBe('s3://logo.png');
+  });
+});

--- a/apps/ccp-admin/src/services/queries/branding.queries.ts
+++ b/apps/ccp-admin/src/services/queries/branding.queries.ts
@@ -11,6 +11,7 @@ import {
   UseMutationOptions,
 } from '@tanstack/react-query';
 import { brandingAPI, type ThemePreset, type BrandingValidationResult, type AssetUploadResponse } from '../api/branding.api';
+import { assetsAPI } from '../api/assets.api';
 import type { BrandingConfig } from '@/pages/Branding';
 
 /**
@@ -185,20 +186,11 @@ export function useUploadAsset(
   options?: UseMutationOptions<
     AssetUploadResponse,
     Error,
-    {
-      file: File;
-      options?: {
-        maxWidth?: number;
-        maxHeight?: number;
-        quality?: number;
-        format?: 'auto' | 'png' | 'jpg' | 'svg';
-      };
-    }
+    { file: File }
   >
 ) {
   return useMutation({
-    mutationFn: ({ file, options: uploadOptions }) => 
-      brandingAPI.uploadAsset(file, uploadOptions),
+    mutationFn: ({ file }) => assetsAPI.uploadAsset(file),
     ...options,
   });
 }


### PR DESCRIPTION
## Summary
- connect admin Branding page to configuration API
- upload logos using new assets API
- validate branding configuration
- add branding query hook tests

## Testing
- `pnpm --filter @agent-desktop/ccp-admin test src/pages/__tests__/Branding.test.tsx` *(fails: Cog6ToothIcon not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6840c66741c08323bc36edff2f08cb2d