### PR TITLE
feat(rtc): add event handling to SoftphoneRTCSession

### DIFF
--- a/apps/ccp-client/src/__mocks__/amazon-connect-rtc-js.ts
+++ b/apps/ccp-client/src/__mocks__/amazon-connect-rtc-js.ts
@@ -1,4 +1,21 @@
 export class SoftphoneRTCSession {
-  on = jest.fn();
-  constructor(public connect: unknown) {}
+  public connect: unknown;
+  private handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+
+  constructor(connect: unknown) {
+    this.connect = connect;
+  }
+
+  on = jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+    if (!this.handlers[event]) {
+      this.handlers[event] = [];
+    }
+    this.handlers[event].push(handler);
+  });
+
+  emit(event: string, ...args: unknown[]): void {
+    for (const handler of this.handlers[event] ?? []) {
+      handler(...args);
+    }
+  }
 }

--- a/libs/amazon-connect-rtc-js/README.md
+++ b/libs/amazon-connect-rtc-js/README.md
@@ -3,3 +3,4 @@
 Local stub implementation of Amazon Connect RTC JS library to enable testing without the proprietary dependency.
 
 This package provides a minimal `SoftphoneRTCSession` class used by the CCP client.
+It now includes a basic event emitter so tests can simulate RTC events.

--- a/libs/amazon-connect-rtc-js/src/index.ts
+++ b/libs/amazon-connect-rtc-js/src/index.ts
@@ -1,7 +1,24 @@
+export type RTCEventHandler = (...args: unknown[]) => void;
+
 export class SoftphoneRTCSession {
+  private handlers: Record<string, RTCEventHandler[]> = {};
+
   constructor(public connect: unknown) {}
 
-  on(_event: string, _handler: (...args: unknown[]) => void): void {
-    // no-op stub for event registration
+  on(event: string, handler: RTCEventHandler): void {
+    if (!this.handlers[event]) {
+      this.handlers[event] = [];
+    }
+    this.handlers[event].push(handler);
+  }
+
+  off(event: string, handler: RTCEventHandler): void {
+    this.handlers[event] = this.handlers[event]?.filter((h) => h !== handler) ?? [];
+  }
+
+  emit(event: string, ...args: unknown[]): void {
+    for (const handler of this.handlers[event] ?? []) {
+      handler(...args);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add event emitter logic to `SoftphoneRTCSession`
- extend mock RTC session to allow emitting events in tests
- document new capabilities in RTC JS stub

## Testing
- `pnpm test` *(fails: Test Suites: 6 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684160aa607c8323beeeedf4c22b10e6