### PR TITLE
Replace customer-info imports with package alias

### DIFF
--- a/apps/ccp-client/package.json
+++ b/apps/ccp-client/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "description": "Amazon Connect Contact Control Panel (CCP) Client Application",
   "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/ccp-client/src/index.ts
+++ b/apps/ccp-client/src/index.ts
@@ -1,0 +1,1 @@
+export { default as ContactInfo } from './components/ContactInfo';

--- a/libs/customer-info/README.md
+++ b/libs/customer-info/README.md
@@ -2,7 +2,7 @@
 
 React component and module wrapper that exposes the **ContactInfo** UI as a loadable module for the Agent Desktop. It provides the default configuration and metadata used by the core module system.
 
-The module simply re-exports the `ContactInfo` component from the `ccp-client` application and can be registered with the `ModuleRegistry` for dynamic loading.
+The module simply re-exports the `ContactInfo` component from the `@agent-desktop/ccp-client` package and can be registered with the `ModuleRegistry` for dynamic loading.
 
 ## Usage
 

--- a/libs/customer-info/jest.config.ts
+++ b/libs/customer-info/jest.config.ts
@@ -9,6 +9,7 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/libs/customer-info',
   moduleNameMapper: {
+    '^@agent-desktop/ccp-client$': '<rootDir>/../../apps/ccp-client/src/index.ts',
     '^@/(.*)$': '<rootDir>/../../apps/ccp-client/src/$1',
   },
 };

--- a/libs/customer-info/src/lib/customer-info.module.ts
+++ b/libs/customer-info/src/lib/customer-info.module.ts
@@ -1,6 +1,6 @@
 import type { ModuleConfig, ModuleID } from '@agent-desktop/types';
 import { BaseModule, ModuleLoadStrategy, type ModuleMetadata } from '@agent-desktop/core';
-import ContactInfo from '../../../../apps/ccp-client/src/components/ContactInfo';
+import { ContactInfo } from '@agent-desktop/ccp-client';
 import type { ComponentType } from 'react';
 
 export const DEFAULT_CUSTOMER_INFO_CONFIG: ModuleConfig = {

--- a/libs/customer-info/src/lib/customer-info.tsx
+++ b/libs/customer-info/src/lib/customer-info.tsx
@@ -1,1 +1,1 @@
-export { default } from '../../../../apps/ccp-client/src/components/ContactInfo';
+export { ContactInfo as default } from '@agent-desktop/ccp-client';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -34,7 +34,8 @@
       "@agent-desktop/logging": ["libs/logging/src/index.ts"],
       "@agent-desktop/testing": ["libs/testing/src/index.ts"],
       "@agent-desktop/types": ["libs/types/src/index.ts"],
-      "@agent-desktop/ui-components": ["libs/ui-components/src/index.ts"]
+      "@agent-desktop/ui-components": ["libs/ui-components/src/index.ts"],
+      "@agent-desktop/ccp-client": ["apps/ccp-client/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## Summary
- expose ContactInfo via `@agent-desktop/ccp-client`
- update customer-info module imports
- add jest alias mapping
- document new export path

## Testing
- `pnpm exec nx lint customer-info` *(fails: 13 problems)*
- `pnpm exec nx test customer-info`

------
https://chatgpt.com/codex/tasks/task_e_684160ac88588323a327e96c0497cefd