### PR TITLE
Configure rtc lib build output

### DIFF
--- a/libs/amazon-connect-rtc-js/package.json
+++ b/libs/amazon-connect-rtc-js/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "description": "Stubbed Amazon Connect RTC JS for testing",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.lib.json",
     "test": "jest",
     "lint": "eslint src --ext ts --report-unused-disable-directives --max-warnings 0",
     "type-check": "tsc --noEmit"

--- a/libs/amazon-connect-rtc-js/tsconfig.lib.json
+++ b/libs/amazon-connect-rtc-js/tsconfig.lib.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "./dist",
+    "rootDir": "./src",
     "declaration": true,
     "types": []
   },


### PR DESCRIPTION
## Summary
- output compiled JavaScript for amazon-connect-rtc-js
- point `main` and `types` to dist build
- update build script and tsconfig paths

## Testing
- `pnpm --filter "./libs/amazon-connect-rtc-js" run build`
- `pnpm --filter "./libs/amazon-connect-rtc-js" exec jest --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684160b15cc88323a3df90671a0a9604