### PR TITLE
Add AWS infrastructure deployment scripts

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -151,41 +151,25 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Install CDK dependencies
-        working-directory: infrastructure/aws-cdk
-        run: pnpm install
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
-      - name: Build Lambda function
-        working-directory: infrastructure/lambda/config-api
-        run: |
-          pnpm install
-          pnpm run build
+      - name: Build Lambda artifacts
+        run: ./infrastructure/scripts/package-lambdas.sh
 
-      - name: CDK Bootstrap (if needed)
-        working-directory: infrastructure/aws-cdk
-        run: |
-          pnpm cdk bootstrap aws://${{ secrets.AWS_ACCOUNT_ID }}/${{ env.AWS_REGION }} || true
-
-      - name: CDK Deploy Production
+      - name: Deploy infrastructure via Nx
         id: deploy
-        working-directory: infrastructure/aws-cdk
-        run: |
-          # Deploy with production context
-          pnpm cdk deploy ccp-config-api-production \
-            --context environment=production \
-            --context terminationProtection=true \
-            --require-approval=never \
-            --outputs-file outputs.json
-          
-          # Extract outputs
-          CONFIG_API_URL=$(cat outputs.json | jq -r '.["ccp-config-api-production"].ConfigApiUrl')
-          CONFIG_TABLE_NAME=$(cat outputs.json | jq -r '.["ccp-config-api-production"].ConfigTableName')
-          
-          echo "config-api-url=$CONFIG_API_URL" >> $GITHUB_OUTPUT
-          echo "config-table-name=$CONFIG_TABLE_NAME" >> $GITHUB_OUTPUT
+        run: pnpm nx deploy:prod aws-cdk --outputs-file infrastructure/aws-cdk/outputs.json
         env:
           CDK_DEFAULT_ACCOUNT: ${{ secrets.AWS_ACCOUNT_ID }}
           CDK_DEFAULT_REGION: ${{ env.AWS_REGION }}
+
+      - name: Extract outputs
+        run: |
+          CONFIG_API_URL=$(cat infrastructure/aws-cdk/outputs.json | jq -r '.["ccp-config-api-production"].ConfigApiUrl')
+          CONFIG_TABLE_NAME=$(cat infrastructure/aws-cdk/outputs.json | jq -r '.["ccp-config-api-production"].ConfigTableName')
+          echo "config-api-url=$CONFIG_API_URL" >> $GITHUB_OUTPUT
+          echo "config-table-name=$CONFIG_TABLE_NAME" >> $GITHUB_OUTPUT
 
   # Deploy Admin Dashboard to production
   deploy-admin-prod:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -120,37 +120,25 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Install CDK dependencies
-        working-directory: infrastructure/aws-cdk
-        run: pnpm install
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
-      - name: Build Lambda function
-        if: needs.changes.outputs.config-api == 'true'
-        working-directory: infrastructure/lambda/config-api
-        run: |
-          pnpm install
-          pnpm run build
+      - name: Build Lambda artifacts
+        run: ./infrastructure/scripts/package-lambdas.sh
 
-      - name: CDK Bootstrap (if needed)
-        working-directory: infrastructure/aws-cdk
-        run: |
-          pnpm cdk bootstrap aws://${{ secrets.AWS_ACCOUNT_ID }}/${{ env.AWS_REGION }} || true
-
-      - name: CDK Deploy
+      - name: Deploy infrastructure via Nx
         id: deploy
-        working-directory: infrastructure/aws-cdk
-        run: |
-          pnpm cdk deploy ccp-config-api-staging --require-approval=never --outputs-file outputs.json
-          
-          # Extract outputs
-          CONFIG_API_URL=$(cat outputs.json | jq -r '.["ccp-config-api-staging"].ConfigApiUrl')
-          CONFIG_TABLE_NAME=$(cat outputs.json | jq -r '.["ccp-config-api-staging"].ConfigTableName')
-          
-          echo "config-api-url=$CONFIG_API_URL" >> $GITHUB_OUTPUT
-          echo "config-table-name=$CONFIG_TABLE_NAME" >> $GITHUB_OUTPUT
+        run: pnpm nx deploy:staging aws-cdk --outputs-file infrastructure/aws-cdk/outputs.json
         env:
           CDK_DEFAULT_ACCOUNT: ${{ secrets.AWS_ACCOUNT_ID }}
           CDK_DEFAULT_REGION: ${{ env.AWS_REGION }}
+
+      - name: Extract outputs
+        run: |
+          CONFIG_API_URL=$(cat infrastructure/aws-cdk/outputs.json | jq -r '.["ccp-config-api-staging"].ConfigApiUrl')
+          CONFIG_TABLE_NAME=$(cat infrastructure/aws-cdk/outputs.json | jq -r '.["ccp-config-api-staging"].ConfigTableName')
+          echo "config-api-url=$CONFIG_API_URL" >> $GITHUB_OUTPUT
+          echo "config-table-name=$CONFIG_TABLE_NAME" >> $GITHUB_OUTPUT
 
   # Deploy CCP Admin Dashboard
   deploy-admin:

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ pnpm nx e2e ccp-client-e2e        # End-to-end tests
 # Infrastructure
 pnpm nx deploy:staging ccp-client # Deploy to staging
 pnpm nx deploy:prod ccp-client    # Deploy to production
+pnpm nx deploy:staging aws-cdk    # Deploy infrastructure to staging
+pnpm nx deploy:prod aws-cdk       # Deploy infrastructure to production
 ```
 
 ## 📱 CCP Client Application
@@ -423,7 +425,7 @@ See [ROADMAP.md](./ROADMAP.md) for detailed feature planning and timeline.
 1. TypeScript build errors in existing store files (in progress)
 2. Library dependencies need proper package.json setup
 3. ESLint configuration needs workspace updates
-4. AWS infrastructure deployment scripts needed
+4. AWS infrastructure can be deployed using the provided Nx targets
 
 ### Workarounds
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,13 +24,15 @@ This performs a production build and syncs the files to the `ccp-client-producti
 
 ## Infrastructure
 
-Infrastructure resources for the configuration API are managed using AWS CDK inside the `infrastructure/aws-cdk` package. Deployment scripts are provided there for each environment:
+Infrastructure resources for the configuration API are managed using AWS CDK inside the `infrastructure/aws-cdk` package. Deployment can be run using Nx targets:
 
 ```bash
-pnpm run deploy:dev     # development
-pnpm run deploy:staging # staging
-pnpm run deploy:prod    # production
+pnpm nx deploy:dev aws-cdk     # development
+pnpm nx deploy:staging aws-cdk # staging
+pnpm nx deploy:prod aws-cdk    # production
 ```
+
+For local convenience, you can also run `scripts/deploy-infra.sh <environment>` which wraps the Nx commands.
 
 ### Asset Storage
 

--- a/infrastructure/aws-cdk/project.json
+++ b/infrastructure/aws-cdk/project.json
@@ -1,0 +1,44 @@
+{
+  "name": "aws-cdk",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "infrastructure/aws-cdk",
+  "projectType": "application",
+  "tags": ["scope:infrastructure"],
+  "targets": {
+    "build": {
+      "executor": "@nx/workspace:run-commands",
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "infrastructure/aws-cdk"
+      }
+    },
+    "deploy:dev": {
+      "executor": "@nx/workspace:run-commands",
+      "options": {
+        "command": "pnpm run deploy:dev",
+        "cwd": "infrastructure/aws-cdk"
+      }
+    },
+    "deploy:staging": {
+      "executor": "@nx/workspace:run-commands",
+      "options": {
+        "command": "pnpm run deploy:staging",
+        "cwd": "infrastructure/aws-cdk"
+      }
+    },
+    "deploy:prod": {
+      "executor": "@nx/workspace:run-commands",
+      "options": {
+        "command": "pnpm run deploy:prod",
+        "cwd": "infrastructure/aws-cdk"
+      }
+    },
+    "destroy": {
+      "executor": "@nx/workspace:run-commands",
+      "options": {
+        "command": "pnpm run destroy",
+        "cwd": "infrastructure/aws-cdk"
+      }
+    }
+  }
+}

--- a/infrastructure/scripts/package-lambdas.sh
+++ b/infrastructure/scripts/package-lambdas.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+for lambda_dir in "$ROOT_DIR"/lambda/*; do
+  if [ -f "$lambda_dir/package.json" ]; then
+    echo "\n==> Building $(basename "$lambda_dir")"
+    (cd "$lambda_dir" && pnpm install --frozen-lockfile && pnpm run package)
+  fi
+done

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "workspaces": [
     "apps/*",
     "libs/*",
-    "tools/*"
+    "tools/*",
+    "infrastructure/*"
   ],
   "scripts": {
     "build": "nx run-many --target=build --all --parallel=3",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - 'apps/*'
   - 'libs/*'
   - 'tools/*'
+  - 'infrastructure/*'

--- a/scripts/deploy-infra.sh
+++ b/scripts/deploy-infra.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENVIRONMENT=${1:-staging}
+
+pnpm nx deploy:$ENVIRONMENT aws-cdk


### PR DESCRIPTION
## Summary
- include `infrastructure/*` packages in the pnpm workspace
- expose Nx project for the AWS CDK stack
- add packaging script for Lambda functions
- update deployment workflows to use Nx targets
- document infrastructure deployment commands and script

## Testing
- `pnpm lint` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841656fc5248323936a4b0f36026eab