### PR TITLE
feat(core): support esm module loading

### DIFF
--- a/libs/core/src/registry/module-registry.service.spec.ts
+++ b/libs/core/src/registry/module-registry.service.spec.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { ModuleRegistryService } from './module-registry.service';
+import type { ModuleID } from '@agent-desktop/types';
+
+describe('ModuleRegistryService - ESM publishModule', () => {
+  let tmpDir: string;
+  let modulesRoot: string;
+  let registryFile: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'registry-'));
+    modulesRoot = path.join(tmpDir, 'modules');
+    registryFile = path.join(tmpDir, 'registry.json');
+    fs.mkdirSync(modulesRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('publishes module using dynamic import when require is unavailable', async () => {
+    const moduleDir = path.join(tmpDir, 'good');
+    fs.mkdirSync(moduleDir);
+    fs.copyFileSync(
+      path.resolve(__dirname, '../__tests__/modules/good-module.js'),
+      path.join(moduleDir, 'index.js'),
+    );
+    const logger = global.TestUtils.createMockLogger();
+    const service = new ModuleRegistryService(registryFile, modulesRoot, logger);
+
+    const originalRequire = (global as any).require;
+    (global as any).require = undefined;
+    try {
+      const record = await service.publishModule(moduleDir);
+      expect(record.id).toBe('good-module');
+      const meta = service.getModuleMetadata('good-module' as ModuleID);
+      expect(meta?.filePath).toBeDefined();
+      expect(fs.existsSync(meta!.filePath)).toBe(true);
+    } finally {
+      (global as any).require = originalRequire;
+    }
+  });
+});

--- a/libs/core/src/registry/module-registry.service.ts
+++ b/libs/core/src/registry/module-registry.service.ts
@@ -50,7 +50,14 @@ export class ModuleRegistryService {
 
   async publishModule(moduleDir: string): Promise<ModulePackageMetadata> {
     const modulePath = path.resolve(moduleDir, 'index.js');
-    const mod = require(modulePath);
+    let mod: any;
+    // Use dynamic import when running under ESM
+    if (typeof require === 'function') {
+      mod = require(modulePath);
+    } else {
+      const { pathToFileURL } = await import('url');
+      mod = await import(pathToFileURL(modulePath).href);
+    }
     const ModuleClass = mod.default || mod.Module || mod;
     const instance = new ModuleClass();
     const metadata = instance.metadata as {


### PR DESCRIPTION
## Summary
- load modules in registry service using dynamic import when running under ESM
- add test covering publishing modules under ESM environment

## Testing
- `pnpm exec nx run core:test`

------
https://chatgpt.com/codex/tasks/task_e_6841e47fa0148323bc10d16a3693b0e5