### PR TITLE
Fix WebSocket import and update tests

### DIFF
--- a/libs/config/package.json
+++ b/libs/config/package.json
@@ -16,7 +16,8 @@
     "@agent-desktop/types": "workspace:*",
     "@agent-desktop/logging": "workspace:*",
     "@aws-sdk/client-dynamodb": "^3.500.0",
-    "@aws-sdk/lib-dynamodb": "^3.500.0"
+    "@aws-sdk/lib-dynamodb": "^3.500.0",
+    "ws": "^8.18.2"
   },
   "devDependencies": {
     "typescript": "^5.0.2",

--- a/libs/config/src/test-setup.ts
+++ b/libs/config/src/test-setup.ts
@@ -2,6 +2,11 @@
  * @fileoverview Test setup for configuration library
  */
 
+// Provide a WebSocket implementation for Node-based tests
+// so that modules using WebSocket can run without errors.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+(globalThis as any).WebSocket = require('ws');
+
 // Global test utilities for configuration
 global.ConfigTestUtils = {
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,6 +505,9 @@ importers:
       '@aws-sdk/lib-dynamodb':
         specifier: ^3.500.0
         version: 3.823.0(@aws-sdk/client-dynamodb@3.823.0)
+      ws:
+        specifier: ^8.18.2
+        version: 8.18.2
     devDependencies:
       '@types/jest':
         specifier: ^29.5.5
@@ -12675,7 +12678,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-    dev: true
 
   /xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}


### PR DESCRIPTION
## Summary
- use `ws` when browser WebSocket isn't present
- make WebSocket available in config test setup
- add `ws` dependency for config package

## Testing
- `pnpm nx test config -- --runInBand --silent` *(fails: DynamoDBConfigStore › saveCustomerConfig › should successfully save a customer configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6841e47f7a2483239f24db2639b4c2cc