### PR TITLE
Fix logger context for AdminWebSocketService

### DIFF
--- a/apps/ccp-admin/src/services/websocket/websocket.service.ts
+++ b/apps/ccp-admin/src/services/websocket/websocket.service.ts
@@ -81,7 +81,7 @@ export class AdminWebSocketService {
 
   constructor(options: Partial<WebSocketOptions> = {}, logger?: Logger) {
     this.logger = logger?.createChild('AdminWebSocketService') || new Logger({
-      service: 'AdminWebSocketService',
+      context: 'AdminWebSocketService',
       level: 'info',
     });
 


### PR DESCRIPTION
## Summary
- use the `context` field when constructing the logger for AdminWebSocketService

## Testing
- `pnpm test` *(fails: Test Suites: 6 failed, 2 passed, 8 total)*

------
https://chatgpt.com/codex/tasks/task_e_6841e4810fac83239d178243a4fdb575