### PR TITLE
Fix TS6133 unused variable warnings

### DIFF
--- a/apps/ccp-admin/src/__mocks__/@aws-sdk/client-dynamodb.ts
+++ b/apps/ccp-admin/src/__mocks__/@aws-sdk/client-dynamodb.ts
@@ -1,5 +1,5 @@
 export class DynamoDBClient {
-  constructor(config?: any) {}
+  constructor(_config?: any) {}
   
   send = jest.fn().mockResolvedValue({});
   destroy = jest.fn();

--- a/apps/ccp-admin/src/__mocks__/@aws-sdk/lib-dynamodb.ts
+++ b/apps/ccp-admin/src/__mocks__/@aws-sdk/lib-dynamodb.ts
@@ -1,32 +1,32 @@
 export class DynamoDBDocumentClient {
   static from = jest.fn().mockReturnValue(new DynamoDBDocumentClient());
-  
-  constructor(client?: any, translateConfig?: any) {}
+
+  constructor(_client?: any, _translateConfig?: any) {}
   
   send = jest.fn().mockResolvedValue({});
   destroy = jest.fn();
 }
 
 export class GetCommand {
-  constructor(input: any) {}
+  constructor(_input: any) {}
 }
 
 export class PutCommand {
-  constructor(input: any) {}
+  constructor(_input: any) {}
 }
 
 export class UpdateCommand {
-  constructor(input: any) {}
+  constructor(_input: any) {}
 }
 
 export class DeleteCommand {
-  constructor(input: any) {}
+  constructor(_input: any) {}
 }
 
 export class QueryCommand {
-  constructor(input: any) {}
+  constructor(_input: any) {}
 }
 
 export class ScanCommand {
-  constructor(input: any) {}
+  constructor(_input: any) {}
 }

--- a/apps/ccp-admin/src/pages/Branding.tsx
+++ b/apps/ccp-admin/src/pages/Branding.tsx
@@ -4,7 +4,6 @@ import {
   PhotoIcon,
   CodeBracketIcon,
   EyeIcon,
-  DocumentDuplicateIcon,
   CheckCircleIcon,
   ExclamationTriangleIcon,
   ArrowDownTrayIcon,

--- a/apps/ccp-admin/src/pages/Modules.tsx
+++ b/apps/ccp-admin/src/pages/Modules.tsx
@@ -2,14 +2,8 @@ import React, { useState } from 'react';
 import {
   MagnifyingGlassIcon,
   PlusIcon,
-  EyeIcon,
-  DocumentTextIcon,
-  CodeBracketIcon,
   Cog6ToothIcon,
   CubeIcon,
-  ExclamationTriangleIcon,
-  XCircleIcon,
-  ChevronRightIcon,
 } from '@heroicons/react/24/outline';
 import { Dialog, Switch } from '@headlessui/react';
 

--- a/apps/ccp-admin/src/pages/__tests__/Branding.test.tsx
+++ b/apps/ccp-admin/src/pages/__tests__/Branding.test.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
-import Branding, { type BrandingConfig } from '../Branding';
+import Branding from '../Branding';
 import { CustomerAPIService } from '@/services/api/customers.api';
 import { assetsAPI } from '@/services/api/assets.api';
 

--- a/apps/ccp-admin/src/pages/__tests__/Modules.test.tsx
+++ b/apps/ccp-admin/src/pages/__tests__/Modules.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import Modules, { type Module, type DependencyCheck } from '../Modules';
+import Modules from '../Modules';
 
 // Mock @headlessui/react
 jest.mock('@headlessui/react', () => ({

--- a/apps/ccp-admin/src/services/api/__tests__/base.api.test.ts
+++ b/apps/ccp-admin/src/services/api/__tests__/base.api.test.ts
@@ -5,7 +5,7 @@
 
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { BaseAPIService } from '../base.api';
-import { ErrorHandler, APIError, NetworkError } from '../../errors';
+import { APIError } from '../../errors';
 
 // Mock axios
 jest.mock('axios');
@@ -292,7 +292,7 @@ describe('BaseAPIService', () => {
           },
         } as AxiosResponse;
 
-        mockAxiosInstance.post.mockImplementation((url, data, config) => {
+        mockAxiosInstance.post.mockImplementation((_url, _data, config) => {
           // Simulate upload progress
           if (config?.onUploadProgress) {
             config.onUploadProgress({ loaded: 50, total: 100 } as any);


### PR DESCRIPTION
## Summary
- update mocks to ignore unused constructor params
- remove unused icons and type imports
- adjust tests for unused imports
- rename unused parameters in Base API tests

## Testing
- `pnpm exec nx run-many --target=lint --all --parallel=3` *(fails: Command "nx" not found)*
- `pnpm exec tsc -p apps/ccp-admin/tsconfig.json` *(fails to compile due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841f78dfb748323b20a24966eea4629