### PR TITLE
Fix heroicons type mismatch

### DIFF
--- a/apps/ccp-admin/src/components/Sidebar.tsx
+++ b/apps/ccp-admin/src/components/Sidebar.tsx
@@ -1,4 +1,9 @@
 import React from 'react';
+import type {
+  ForwardRefExoticComponent,
+  RefAttributes,
+  SVGProps,
+} from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import { 
   HomeIcon,
@@ -15,7 +20,12 @@ import {
 interface NavItem {
   name: string;
   href: string;
-  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  icon: ForwardRefExoticComponent<
+    Omit<SVGProps<SVGSVGElement>, 'ref'> & {
+      title?: string;
+      titleId?: string;
+    } & RefAttributes<SVGSVGElement>
+  >;
   description: string;
 }
 

--- a/apps/ccp-admin/src/pages/Settings.tsx
+++ b/apps/ccp-admin/src/pages/Settings.tsx
@@ -1,4 +1,9 @@
 import React, { useState } from 'react';
+import type {
+  ForwardRefExoticComponent,
+  RefAttributes,
+  SVGProps,
+} from 'react';
 import {
   Cog6ToothIcon,
   ShieldCheckIcon,
@@ -15,7 +20,12 @@ interface SettingsSection {
   id: string;
   name: string;
   description: string;
-  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  icon: ForwardRefExoticComponent<
+    Omit<SVGProps<SVGSVGElement>, 'ref'> & {
+      title?: string;
+      titleId?: string;
+    } & RefAttributes<SVGSVGElement>
+  >;
 }
 
 /**


### PR DESCRIPTION
## Summary
- fix icon typing in sidebar navigation
- fix icon typing in settings navigation

## Testing
- `pnpm exec nx lint @agent-desktop/ccp-admin` *(fails: couldn't find ESLint config)*
- `pnpm exec nx run @agent-desktop/ccp-admin:type-check` *(fails to compile)*
- `pnpm exec nx test @agent-desktop/ccp-admin` *(fails to execute tests)*

------
https://chatgpt.com/codex/tasks/task_e_6841fb9ee6d08323b8f0d0136d876c14