### PR TITLE
fix: handle optional logo dimensions

### DIFF
--- a/apps/ccp-admin/src/pages/Branding.tsx
+++ b/apps/ccp-admin/src/pages/Branding.tsx
@@ -323,7 +323,14 @@ function LogoUpload({
             <input
               type="number"
               value={logo.width || ''}
-              onChange={(e) => onLogoChange({ width: parseInt(e.target.value) || undefined })}
+              onChange={(e) => {
+                const value = parseInt(e.target.value, 10);
+                if (isNaN(value)) {
+                  onLogoChange({});
+                } else {
+                  onLogoChange({ width: value });
+                }
+              }}
               className="input"
               placeholder="Auto"
               min="50"
@@ -337,7 +344,14 @@ function LogoUpload({
             <input
               type="number"
               value={logo.height || ''}
-              onChange={(e) => onLogoChange({ height: parseInt(e.target.value) || undefined })}
+              onChange={(e) => {
+                const value = parseInt(e.target.value, 10);
+                if (isNaN(value)) {
+                  onLogoChange({});
+                } else {
+                  onLogoChange({ height: value });
+                }
+              }}
               className="input"
               placeholder="Auto"
               min="20"


### PR DESCRIPTION
## Summary
- avoid passing `undefined` for logo width/height when `exactOptionalPropertyTypes` is enabled

## Testing
- `pnpm --filter @agent-desktop/ccp-admin lint` *(fails: ESLint couldn't find configuration)*
- `pnpm --filter @agent-desktop/ccp-admin test` *(fails: jest not found)*
- `pnpm --filter @agent-desktop/ccp-admin type-check` *(fails: package dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841fde772b483238c97b53ef78e579f