### PR TITLE
Fix StatCard icon type mismatch

### DIFF
--- a/apps/ccp-admin/src/pages/Dashboard.tsx
+++ b/apps/ccp-admin/src/pages/Dashboard.tsx
@@ -1,4 +1,9 @@
 import React, { useMemo } from 'react';
+import type {
+  ForwardRefExoticComponent,
+  RefAttributes,
+  SVGProps,
+} from 'react';
 import { subDays, formatDistanceToNow } from 'date-fns';
 import {
   UserGroupIcon,
@@ -18,7 +23,12 @@ interface StatCard {
   value: string | number;
   change?: string;
   changeType?: 'increase' | 'decrease' | 'neutral';
-  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  icon: ForwardRefExoticComponent<
+    Omit<SVGProps<SVGSVGElement>, 'ref'> & {
+      title?: string;
+      titleId?: string;
+    } & RefAttributes<SVGSVGElement>
+  >;
 }
 
 /**


### PR DESCRIPTION
## Summary
- update `StatCard` icon type to match Heroicons

## Testing
- `pnpm test` *(fails: Test Suites 3 failed)*
- `pnpm lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684221fb5a8c832392e41be991fe1dcc