### PR TITLE
Fix Switch checked prop type mismatch

### DIFF
--- a/apps/ccp-admin/src/pages/Modules.tsx
+++ b/apps/ccp-admin/src/pages/Modules.tsx
@@ -617,11 +617,13 @@ function Modules(): React.ReactElement {
             <div className="px-6 py-4 bg-gray-50 border-t border-gray-200 flex items-center justify-between">
               <div className="flex items-center space-x-2">
                 <Switch
-                  checked={module.enabled}
+                  checked={module.enabled ?? false}
                   onChange={() =>
                     setModuleList(prev =>
                       prev.map(m =>
-                        m.id === module.id ? { ...m, enabled: !m.enabled } : m
+                        m.id === module.id
+                          ? { ...m, enabled: !(m.enabled ?? false) }
+                          : m
                       )
                     )
                   }


### PR DESCRIPTION
## Summary
- ensure Switch checked prop is a boolean in the Modules page

## Testing
- `pnpm lint` *(fails: Running target lint for 10 projects failed)*
- `pnpm type-check` *(fails: Running target type-check for 8 projects failed)*
- `pnpm test` *(fails: Test Suites: 3 failed, 1 passed, 4 total)*

------
https://chatgpt.com/codex/tasks/task_e_6842221463b0832385dc0d5200b306c1