### PR TITLE
Fix type-check dependency chain

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -37,6 +37,7 @@
       "cache": true
     },
     "type-check": {
+      "dependsOn": ["^build"],
       "inputs": ["default", "^production"],
       "cache": true
     },


### PR DESCRIPTION
## Summary
- ensure `type-check` depends on library `build` output

## Testing
- `pnpm install`
- `pnpm nx run-many --target=build --all --parallel=3` *(fails: Unable to resolve @nx/workspace:run-commands)*
- `pnpm nx run-many --target=type-check --all --parallel=3` *(fails: tasks dependency error)*

------
https://chatgpt.com/codex/tasks/task_e_68422257c9448323a0e70286fd1c59ce