### PR TITLE
fix: add override modifiers

### DIFF
--- a/apps/ccp-admin/src/providers/APIProvider.tsx
+++ b/apps/ccp-admin/src/providers/APIProvider.tsx
@@ -84,11 +84,11 @@ class APIErrorBoundary extends React.Component<
     this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError(error: Error) {
+  static override getDerivedStateFromError(error: Error) {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+  override componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error('API Error Boundary caught an error:', error, errorInfo);
 
     // Log to external service in production


### PR DESCRIPTION
## Summary
- add `override` modifier in APIErrorBoundary lifecycle methods

## Testing
- `pnpm test` *(fails: Test Suites: 6 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6842228502dc8323a1bf1c6ebbe4b7a9