### PR TITLE
Fix type-only imports in admin API tests

### DIFF
--- a/apps/ccp-admin/src/services/api/__tests__/base.api.test.ts
+++ b/apps/ccp-admin/src/services/api/__tests__/base.api.test.ts
@@ -3,7 +3,8 @@
  * @module services/api/__tests__/base.api
  */
 
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios from 'axios';
+import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { BaseAPIService } from '../base.api';
 import { APIError } from '../../errors';
 


### PR DESCRIPTION
## Summary
- use `import type` for Axios types in BaseAPIService tests

## Testing
- `pnpm test` *(fails: Test Suites: 3 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684222e463748323a407c5e3788cd8b0