### PR TITLE
Fix audit log pagination types

### DIFF
--- a/apps/ccp-admin/src/services/api/analytics.api.ts
+++ b/apps/ccp-admin/src/services/api/analytics.api.ts
@@ -18,6 +18,7 @@ import type {
   AnalyticsChart,
   SystemHealthResponse,
   AuditLogResponse,
+  AuditLogEntry,
 } from '../types/responses.types';
 
 /**
@@ -301,17 +302,22 @@ export class AnalyticsAPIService extends BaseAPIService {
 
     const params = this.buildAuditLogFilters(filters);
 
-    return this.getPaginated<AuditLogResponse['items']>(
+    const paginatedItemsResponse = await this.getPaginated<AuditLogEntry>(
       `${this.baseEndpoint}/audit/logs`,
       params
-    ).then(async (response) => {
-      // Enhance response with summary information
-      const summary = await this.getAuditLogSummary(filters);
-      return {
-        ...response,
-        summary,
-      } as AuditLogResponse;
-    });
+    );
+
+    const summary = await this.getAuditLogSummary(filters);
+
+    return {
+      items: paginatedItemsResponse.items,
+      total: paginatedItemsResponse.total,
+      page: paginatedItemsResponse.page,
+      pageSize: paginatedItemsResponse.pageSize,
+      hasNextPage: paginatedItemsResponse.hasNextPage,
+      hasPreviousPage: paginatedItemsResponse.hasPreviousPage,
+      summary,
+    };
   }
 
   /**

--- a/apps/ccp-admin/src/services/api/base.api.ts
+++ b/apps/ccp-admin/src/services/api/base.api.ts
@@ -250,13 +250,13 @@ export abstract class BaseAPIService {
   /**
    * GET request with pagination support
    */
-  protected async getPaginated<T>(
+  protected async getPaginated<ItemType>(
     endpoint: string,
     params?: Record<string, unknown>,
     config?: AxiosRequestConfig
-  ): Promise<PaginatedResponse<T>> {
+  ): Promise<PaginatedResponse<ItemType>> {
     try {
-      const response = await this.client.get<APIResponse<PaginatedResponse<T>>>(
+      const response = await this.client.get<APIResponse<PaginatedResponse<ItemType>>>(
         endpoint,
         {
           ...config,


### PR DESCRIPTION
## Summary
- correctly type audit log items pagination
- clarify generic name in `getPaginated`

## Testing
- `pnpm test` *(fails: nx not found)*
- `pnpm lint` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422311775c8323a507ce996881370a