### PR TITLE
Fix Vite env types

### DIFF
--- a/apps/ccp-admin/tsconfig.json
+++ b/apps/ccp-admin/tsconfig.json
@@ -16,6 +16,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client", "jest", "node"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],


### PR DESCRIPTION
## Summary
- enable Vite `import.meta.env` types in ccp-admin tsconfig

## Testing
- `pnpm type-check` *(fails: Output files not built)*

------
https://chatgpt.com/codex/tasks/task_e_6842232625948323adc197ada19bbd19