### PR TITLE
Fix config TS2339

### DIFF
--- a/libs/config/tsconfig.spec.json
+++ b/libs/config/tsconfig.spec.json
@@ -17,6 +17,7 @@
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx",
     "src/**/*.d.ts",
-    "src/test-utils.d.ts"
+    "src/test-utils.d.ts",
+    "src/test-setup.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- add test-setup.ts to config tsconfig.spec.json includes to expose `ConfigTestUtils` globally

## Testing
- `npx tsc -p libs/config/tsconfig.spec.json` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6842233fe7608323b226931f05bddd18