### PR TITLE
Fix core test utils typing

### DIFF
--- a/libs/core/src/test-utils.d.ts
+++ b/libs/core/src/test-utils.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Global test utilities type declarations for the core library
+ */
+
+declare global {
+  var TestUtils: {
+    createMockLogger: () => {
+      debug: jest.Mock;
+      info: jest.Mock;
+      warn: jest.Mock;
+      error: jest.Mock;
+      fatal: jest.Mock;
+      createChild: jest.Mock;
+      setContext: jest.Mock;
+      time: jest.Mock;
+    };
+    createMockConfig: (overrides?: Record<string, unknown>) => any;
+    createMockModuleContext: (overrides?: Record<string, unknown>) => any;
+    waitFor: (ms?: number) => Promise<void>;
+    flushPromises: () => Promise<void>;
+  };
+
+  // Provide access to configuration test utilities when available
+  var ConfigTestUtils: any;
+  var LoggingTestUtils: any;
+}
+
+export {};


### PR DESCRIPTION
## Summary
- provide `TestUtils` typings for core tests so global helpers are recognized

## Testing
- `npx nx test core`

------
https://chatgpt.com/codex/tasks/task_e_68422354ed448323b5b3e0acd0a9f7f2